### PR TITLE
Add Chai Immutable in the plugins

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -294,4 +294,14 @@ module.exports = [
     , tags: [ 'assertion', 'id', 'objectid', 'equality' ]
     , pkg: 'https://raw.githubusercontent.com/hurrymaplelad/chaid/master/package.json'
     , markdown: 'https://raw.githubusercontent.com/hurrymaplelad/chaid/master/README.md' }
+
+  , { name: 'Chai Immutable'
+    , desc: 'Assertions for Facebook\'s Immutable library for JavaScript collections'
+    , url: 'chai-immutable'
+    , link: 'https://github.com/astorije/chai-immutable'
+    , tags: [ 'assertion', 'immutable', 'equality' ]
+    , pkg: 'https://raw.githubusercontent.com/astorije/chai-immutable/master/package.json'
+    , markdown: 'https://raw.githubusercontent.com/astorije/chai-immutable/master/README.md'
+    , browser: false
+    }
 ];


### PR DESCRIPTION
At the time of sending this PR, Chai Immutable is v0.2.1 and will evolve, maybe without keeping BC depending on the feedback I have. But I already saw some people showing interest in the plugin and I figured I should rather share it sooner than later.

Also, I haven't done anything towards browser support yet but it is planned as [Immutable](http://facebook.github.io/immutable-js/) itself has browser support.

Let me know if you have any other quality requirements to follow to get this accepted and I'll do my best to comply with them ASAP.