### PR TITLE
Updated documentation to Chai version 2.2.0

### DIFF
--- a/data/codex.json
+++ b/data/codex.json
@@ -9,7 +9,7 @@
     "tweeturl": "http://chaijs.com",
     "tweetvia": "jakeluer",
     "tweetrelated": "jakeluer",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "hasdownloads": false,
     "description": "Chai is a BDD / TDD assertion library for [node](http://nodejs.org) and the browser that can be delightfully paired with any javascript testing framework."
   },

--- a/out/api/assert/index.html
+++ b/out/api/assert/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?2.2.0"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/api/bdd/index.html
+++ b/out/api/bdd/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?2.2.0"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -120,6 +120,10 @@ expect({ foo: <span class="string">'baz'</span> }).to.have.property(<span class=
 <pre><code>expect(foo).to.deep.equal({ bar: <span class="string">'baz'</span> });
 expect({ foo: { bar: { baz: <span class="string">'quux'</span> } } })
   .to.have.deep.property(<span class="string">'foo.bar.baz'</span>, <span class="string">'quux'</span>);</code></pre>
+<p><code>.deep.property</code> special characters can be escaped
+by adding two slashes before the <code>.</code> or <code>[]</code>.</p>
+<pre><code><span class="keyword">var</span> deepCss = { <span class="string">'.link'</span>: { <span class="string">'[target]'</span>: <span class="number">42</span> }};
+expect(deepCss).to.have.deep.property(<span class="string">'\\.link.\\[target\\]'</span>, <span class="number">42</span>);</code></pre>
 </div>
               </div>
               <div id="any-section" class="segment">
@@ -218,7 +222,7 @@ expect(<span class="number">0</span>).to.not.be.<span class="literal">false</spa
                 </ul>
                 <div class="description"><p>Asserts that the target is <code>null</code>.</p>
 <pre><code>expect(<span class="literal">null</span>).to.be.<span class="literal">null</span>;
-expect(undefined).not.to.be.<span class="literal">null</span>;</code></pre>
+expect(undefined).to.not.be.<span class="literal">null</span>;</code></pre>
 </div>
               </div>
               <div id="undefined-section" class="segment">
@@ -251,7 +255,7 @@ expect(baz).to.not.exist;</code></pre>
 </div>
                 <ul class="tags">
                 </ul>
-                <div class="description"><p>Asserts that the target&#39;s length is <code>0</code>. For arrays, it checks
+                <div class="description"><p>Asserts that the target&#39;s length is <code>0</code>. For arrays and strings, it checks
 the <code>length</code> property. For objects, it gets the count of
 enumerable keys.</p>
 <pre><code>expect([]).to.be.empty;
@@ -449,6 +453,16 @@ expect(deepObj).to.have.property(<span class="string">'teas'</span>)
   .that.is.an(<span class="string">'array'</span>)
   .<span class="keyword">with</span>.deep.property(<span class="string">'[2]'</span>)
     .that.deep.equals({ tea: <span class="string">'konacha'</span> });</code></pre>
+<p>Note that dots and bracket in <code>name</code> must be backslash-escaped when
+the <code>deep</code> flag is set, while they must NOT be escaped when the <code>deep</code>
+flag is not set.</p>
+<pre><code><span class="comment">// simple referencing</span>
+<span class="keyword">var</span> css = { <span class="string">'.link[target]'</span>: <span class="number">42</span> };
+expect(css).to.have.property(<span class="string">'.link[target]'</span>, <span class="number">42</span>);
+
+<span class="comment">// deep referencing</span>
+<span class="keyword">var</span> deepCss = { <span class="string">'.link'</span>: { <span class="string">'[target]'</span>: <span class="number">42</span> }};
+expect(deepCss).to.have.deep.property(<span class="string">'\\.link.\\[target\\]'</span>, <span class="number">42</span>);</code></pre>
 </div>
               </div>
               <div id="ownProperty-section" class="segment">

--- a/out/api/index.html
+++ b/out/api/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?2.2.0"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/api/plugins/index.html
+++ b/out/api/plugins/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?2.2.0"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/api/test/index.html
+++ b/out/api/test/index.html
@@ -10,7 +10,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/tests/mocha.js"></script>
     <script>mocha.setup('tdd');</script>
     <script src="/chai.js"></script>
@@ -40,8 +40,8 @@
       };
       
     </script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/chai.js
+++ b/out/chai.js
@@ -678,7 +678,7 @@ var used = []
  * Chai version
  */
 
-exports.version = '2.1.0';
+exports.version = '2.2.0';
 
 /*!
  * Assertion Error
@@ -852,10 +852,11 @@ module.exports = function (_chai, util) {
    *
    * @name assert
    * @param {Philosophical} expression to be tested
-   * @param {String or Function} message or function that returns message to display if fails
+   * @param {String or Function} message or function that returns message to display if expression fails
    * @param {String or Function} negatedMessage or function that returns negatedMessage to display if negated expression fails
    * @param {Mixed} expected value (remember to check for negation)
    * @param {Mixed} actual (optional) will default to `this.obj`
+   * @param {Boolean} showDiff (optional) when set to `true`, assert will display a diff in addition to the message if expression fails
    * @api private
    */
 
@@ -932,10 +933,15 @@ module.exports = {
    * ### config.truncateThreshold
    *
    * User configurable property, sets length threshold for actual and
-   * expected values in assertion errors. If this threshold is exceeded,
-   * the value is truncated.
+   * expected values in assertion errors. If this threshold is exceeded, for
+   * example for large data structures, the value is replaced with something
+   * like `[ Array(3) ]` or `{ Object (prop1, prop2) }`.
    *
    * Set it to zero if you want to disable truncating altogether.
+   *
+   * This is especially userful when doing assertions on arrays: having this
+   * set to a reasonable large value makes the failure messages readily
+   * inspectable.
    *
    *     chai.config.truncateThreshold = 0;  // disable truncating
    *
@@ -1026,6 +1032,12 @@ module.exports = function (chai, _) {
    *     expect(foo).to.deep.equal({ bar: 'baz' });
    *     expect({ foo: { bar: { baz: 'quux' } } })
    *       .to.have.deep.property('foo.bar.baz', 'quux');
+   *
+   * `.deep.property` special characters can be escaped
+   * by adding two slashes before the `.` or `[]`.
+   *
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
    *
    * @name deep
    * @api public
@@ -1300,7 +1312,7 @@ module.exports = function (chai, _) {
   /**
    * ### .empty
    *
-   * Asserts that the target's length is `0`. For arrays, it checks
+   * Asserts that the target's length is `0`. For arrays and strings, it checks
    * the `length` property. For objects, it gets the count of
    * enumerable keys.
    *
@@ -1713,7 +1725,7 @@ module.exports = function (chai, _) {
    *         green: { tea: 'matcha' }
    *       , teas: [ 'chai', 'matcha', { tea: 'konacha' } ]
    *     };
-
+   * 
    *     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');
@@ -1744,6 +1756,18 @@ module.exports = function (chai, _) {
    *       .that.is.an('array')
    *       .with.deep.property('[2]')
    *         .that.deep.equals({ tea: 'konacha' });
+   *
+   * Note that dots and bracket in `name` must be backslash-escaped when
+   * the `deep` flag is set, while they must NOT be escaped when the `deep`
+   * flag is not set.
+   *
+   *     // simple referencing
+   *     var css = { '.link[target]': 42 };
+   *     expect(css).to.have.property('.link[target]', 42);
+   *
+   *     // deep referencing
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
    *
    * @name property
    * @alias deep.property
@@ -3494,10 +3518,36 @@ module.exports = function (chai, util) {
    */
 
   assert.operator = function (val, operator, val2, msg) {
-    if (!~['==', '===', '>', '>=', '<', '<=', '!=', '!=='].indexOf(operator)) {
-      throw new Error('Invalid operator "' + operator + '"');
+    var ok;
+    switch(operator) {
+      case '==':
+        ok = val == val2;
+        break;
+      case '===':
+        ok = val === val2;
+        break;
+      case '>':
+        ok = val > val2;
+        break;
+      case '>=':
+        ok = val >= val2;
+        break;
+      case '<':
+        ok = val < val2;
+        break;
+      case '<=':
+        ok = val <= val2;
+        break;
+      case '!=':
+        ok = val != val2;
+        break;
+      case '!==':
+        ok = val !== val2;
+        break;
+      default:
+        throw new Error('Invalid operator "' + operator + '"');
     }
-    var test = new Assertion(eval(val + operator + val2), msg);
+    var test = new Assertion(ok, msg);
     test.assert(
         true === flag(test, 'object')
       , 'expected ' + util.inspect(val) + ' to be ' + operator + ' ' + util.inspect(val2)
@@ -3778,10 +3828,8 @@ module.exports = function (chai, util) {
   function loadShould () {
     // explicitly define this method as function as to have it's name to include as `ssfi`
     function shouldGetter() {
-      if (this instanceof String || this instanceof Number) {
-        return new Assertion(this.constructor(this), null, shouldGetter);
-      } else if (this instanceof Boolean) {
-        return new Assertion(this == true, null, shouldGetter);
+      if (this instanceof String || this instanceof Number || this instanceof Boolean ) {
+        return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);
     }
@@ -4321,7 +4369,7 @@ module.exports = function getPathInfo(path, obj) {
       last = parsed[parsed.length - 1];
 
   var info = {
-    parent: _getPathValue(parsed, obj, parsed.length - 1),
+    parent: parsed.length > 1 ? _getPathValue(parsed, obj, parsed.length - 1) : obj,
     name: last.p || last.i,
     value: _getPathValue(parsed, obj),
   };
@@ -4343,6 +4391,7 @@ module.exports = function getPathInfo(path, obj) {
  *
  * * Can be as near infinitely deep and nested
  * * Arrays are also valid using the formal `myobject.document[3].property`.
+ * * Literal dots and brackets (not delimiter) must be backslash-escaped.
  *
  * @param {String} path
  * @returns {Object} parsed
@@ -4350,13 +4399,13 @@ module.exports = function getPathInfo(path, obj) {
  */
 
 function parsePath (path) {
-  var str = path.replace(/\[/g, '.[')
+  var str = path.replace(/([^\\])\[/g, '$1.[')
     , parts = str.match(/(\\\.|[^.]+?)+/g);
   return parts.map(function (value) {
-    var re = /\[(\d+)\]$/
+    var re = /^\[(\d+)\]$/
       , mArr = re.exec(value);
     if (mArr) return { i: parseFloat(mArr[1]) };
-    else return { p: value };
+    else return { p: value.replace(/\\([.\[\]])/g, '$1') };
   });
 }
 

--- a/out/guide/helpers/index.html
+++ b/out/guide/helpers/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/index.html
+++ b/out/guide/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/installation/index.html
+++ b/out/guide/installation/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/plugins/index.html
+++ b/out/guide/plugins/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/resources/index.html
+++ b/out/guide/resources/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/styles/index.html
+++ b/out/guide/styles/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -131,7 +131,7 @@ booleans or numbers.</p>
               <article id="should-section"><h3 id="should">Should</h3>
 <p>The <code>should</code> style allows for the same chainable assertions as the
 <code>expect</code> interface, however it extends each object with a <code>should</code>
-property to start your chain. This style has some issues when used Internet
+property to start your chain. This style has some issues when used with Internet
 Explorer, so be aware of browser compatibility. </p>
 <pre><code><span class="keyword">var</span> should = require(<span class="string">'chai'</span>).should() <span class="comment">//actually call the function</span>
   , foo = <span class="string">'bar'</span>

--- a/out/index.html
+++ b/out/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?2.2.0"></script>
     <script src="/public/js/home.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?2.2.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?2.2.0" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -59,7 +59,7 @@
           <div class="card-wrap">
             <div class="card">
               <div class="card-inner">
-                <h1>Download Chai<span class="version">v2.1.0</span></h1>
+                <h1>Download Chai<span class="version">v2.2.0</span></h1>
                 <div id="node" class="install">
                   <h2>for Node<small>Another platform?<a href="#browser" class="toggle">Browser</a><a href="#rails" class="toggle">Rails</a></small></h2>
                   <div class="download-banner"> 

--- a/out/public/js/tests/assert.js
+++ b/out/public/js/tests/assert.js
@@ -556,6 +556,9 @@ describe('assert', function () {
   });
 
   it('operator', function() {
+    // For testing undefined and null with == and ===
+    var w;
+    
     assert.operator(1, '<', 2);
     assert.operator(2, '>', 1);
     assert.operator(1, '==', 1);
@@ -563,6 +566,10 @@ describe('assert', function () {
     assert.operator(1, '>=', 1);
     assert.operator(1, '!=', 2);
     assert.operator(1, '!==', 2);
+    assert.operator(1, '!==', '1');
+    assert.operator(w, '==', undefined);
+    assert.operator(w, '===', undefined);
+    assert.operator(w, '==', null);
 
     err(function () {
       assert.operator(1, '=', 2);
@@ -579,6 +586,10 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '==', 2);
      }, "expected 1 to be == 2");
+     
+    err(function () {
+      assert.operator(1, '===', '1');
+     }, "expected 1 to be === \'1\'");
 
     err(function () {
       assert.operator(2, '<=', 1);
@@ -591,10 +602,16 @@ describe('assert', function () {
     err(function () {
       assert.operator(1, '!=', 1);
      }, "expected 1 to be != 1");
-
+     
     err(function () {
-      assert.operator(1, '!==', '1');
-     }, "expected 1 to be !== \'1\'");
+      assert.operator(1, '!==', 1);
+     }, "expected 1 to be !== 1");
+    
+    err(function () {
+      assert.operator(w, '===', null);
+     }, "expected undefined to be === null");
+     
+     
   });
 
   it('closeTo', function(){

--- a/out/public/js/tests/expect.js
+++ b/out/public/js/tests/expect.js
@@ -411,6 +411,9 @@ describe('expect', function () {
     expect(obj).to.have.property('foo');
     expect(obj).to.have.property('bar');
 
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.property('foo.bar[]');
+
     err(function(){
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
@@ -429,6 +432,9 @@ describe('expect', function () {
     expect({ 'foo': [1, 2, 3] })
       .to.have.deep.property('foo[1]');
 
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.deep.property('foo\\.bar\\[\\]');
+
     err(function(){
       expect({ 'foo.bar': 'baz' })
         .to.have.deep.property('foo.bar');
@@ -446,6 +452,12 @@ describe('expect', function () {
     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');
+
+    expect(deepObj).to.have.property('teas')
+      .that.is.an('array')
+      .with.deep.property('[2]')
+        .that.deep.equals({tea: 'konacha'});
+
     err(function(){
       expect(deepObj).to.have.deep.property('teas[3]');
     }, "expected { Object (green, teas) } to have a deep property 'teas[3]'");
@@ -455,7 +467,7 @@ describe('expect', function () {
     err(function(){
       expect(deepObj).to.have.deep.property('teas[3].tea', 'bar');
     }, "expected { Object (green, teas) } to have a deep property 'teas[3].tea'");
-    
+
     var arr = [
         [ 'chai', 'matcha', 'konacha' ]
       , [ { tea: 'chai' }
@@ -517,6 +529,40 @@ describe('expect', function () {
     err(function(){
       expect({ length: 12 }).to.not.have.ownProperty('length', 'blah');
     }, "blah: expected { length: 12 } to not have own property 'length'");
+  });
+
+  it('ownPropertyDescriptor(name)', function(){
+    expect('test').to.have.ownPropertyDescriptor('length');
+    expect('test').to.haveOwnPropertyDescriptor('length');
+    expect('test').not.to.have.ownPropertyDescriptor('foo');
+
+    var obj = {};
+    var descriptor = {
+      configurable: false,
+      enumerable: true,
+      writable: true,
+      value: NaN
+    };
+    Object.defineProperty(obj, 'test', descriptor);
+    expect(obj).to.have.ownPropertyDescriptor('test', descriptor);
+    err(function(){
+      expect(obj).not.to.have.ownPropertyDescriptor('test', descriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to not match \{ [^\}]+ \}$/);
+    err(function(){
+      var wrongDescriptor = {
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: NaN
+      };
+      expect(obj).to.have.ownPropertyDescriptor('test', wrongDescriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to match \{ [^\}]+ \}, got \{ [^\}]+ \}$/);
+
+    err(function(){
+      expect(obj).to.have.ownPropertyDescriptor('test2', 'blah');
+    }, "blah: expected { test: NaN } to have an own property descriptor for 'test2'");
+
+    expect(obj).to.have.ownPropertyDescriptor('test').and.have.property('enumerable', true);
   });
 
   it('string()', function(){

--- a/out/public/js/tests/should.js
+++ b/out/public/js/tests/should.js
@@ -396,6 +396,40 @@ describe('should', function() {
     }, "blah: expected { length: 12 } to not have own property 'length'");
   });
 
+  it('ownPropertyDescriptor(name)', function(){
+    'test'.should.haveOwnPropertyDescriptor('length');
+    'test'.should.have.ownPropertyDescriptor('length');
+    'test'.should.not.have.ownPropertyDescriptor('foo');
+
+    var obj = { };
+    var descriptor = {
+      configurable: false,
+      enumerable: true,
+      writable: true,
+      value: NaN
+    };
+    Object.defineProperty(obj, 'test', descriptor);
+    obj.should.haveOwnPropertyDescriptor('test', descriptor);
+    err(function(){
+      obj.should.not.haveOwnPropertyDescriptor('test', descriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to not match \{ [^\}]+ \}$/);
+    err(function(){
+      var wrongDescriptor = {
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: NaN
+      };
+      obj.should.haveOwnPropertyDescriptor('test', wrongDescriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to match \{ [^\}]+ \}, got \{ [^\}]+ \}$/);
+
+    err(function(){
+      obj.should.haveOwnPropertyDescriptor('test2', 'blah');
+    }, "blah: expected { test: NaN } to have an own property descriptor for 'test2'");
+
+    obj.should.have.ownPropertyDescriptor('test').and.have.property('enumerable', true);
+  });
+
   it('string()', function(){
     'foobar'.should.contain.string('bar');
     'foobar'.should.contain.string('foo');

--- a/out/public/js/tests/utilities.js
+++ b/out/public/js/tests/utilities.js
@@ -90,6 +90,9 @@ describe('utilities', function () {
           dimensions: {
             units: 'mm',
             lengths: [[1.2, 3.5], [2.2, 1.5], [5, 7]]
+          },
+          'dimensions.lengths': {
+            '[2]': [1.2, 3.5]
           }
         };
 
@@ -151,6 +154,15 @@ describe('utilities', function () {
       expect(info.value).to.be.undefined;
       info.name.should.equal(5);
       info.exists.should.be.false;
+    });
+
+    it('should handle backslash-escaping for .[]', function() {
+      var info = gpi('dimensions\\.lengths.\\[2\\][1]', obj);
+
+      info.parent.should.equal(obj['dimensions.lengths']['[2]']);
+      info.value.should.equal(obj['dimensions.lengths']['[2]'][1]);
+      info.name.should.equal(1);
+      info.exists.should.be.true;
     });
   });
 


### PR DESCRIPTION
I updated the documentation to match Chai version 2.2.0.

I noticed there were some changes in the /chai/lib/chai/core/assertions.js file that have not yet made it to /chai/chai.js.  So I did not add that to the documentation.  The changes include some trailing whitespace fixes and an addition of an .ownPropertyDescriptor() method.