### PR TITLE
Specify that browser is supported for chai-immutable

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -313,7 +313,8 @@ module.exports = [
     , tags: [ 'assertion', 'immutable', 'equality' ]
     , pkg: 'https://raw.githubusercontent.com/astorije/chai-immutable/master/package.json'
     , markdown: 'https://raw.githubusercontent.com/astorije/chai-immutable/master/README.md'
-    , browser: false
+    , browser:
+      { 'chai-immutable.js': 'https://raw.githubusercontent.com/astorije/chai-immutable/master/chai-immutable.js' }
     }
     
   , { name: 'Chai Signals'


### PR DESCRIPTION
This is true since version 1.3.0: https://github.com/astorije/chai-immutable/releases/tag/v1.3.0