### PR TITLE
Move chai-immutable to the new plugin system

### DIFF
--- a/_legacy_plugins
+++ b/_legacy_plugins
@@ -27,6 +27,5 @@ chai-param
 chai-colors
 chai-xml
 chaid
-chai-immutable
 chai-signals
 chai-match


### PR DESCRIPTION
See https://github.com/astorije/chai-immutable/commit/39540ffc1f4f43f7aa3175eef7a90d59b46665b6

---

Is it enough to add the `chai-plugin` keyword to safely remove this line from the legacy listing?