### PR TITLE
Update docs for Chai 3.4.2

### DIFF
--- a/data/codex.json
+++ b/data/codex.json
@@ -9,7 +9,7 @@
     "tweeturl": "http://chaijs.com",
     "tweetvia": "jakeluer",
     "tweetrelated": "jakeluer",
-    "version": "2.1.0",
+    "version": "3.4.2",
     "hasdownloads": false,
     "description": "Chai is a BDD / TDD assertion library for [node](http://nodejs.org) and the browser that can be delightfully paired with any javascript testing framework."
   },

--- a/out/api/assert/index.html
+++ b/out/api/assert/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?3.4.2"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -56,7 +56,7 @@
           <div class="list box-wrap antiscroll-wrap">
             <div class="box">
               <div class="antiscroll-inner">
-                <div class="box-inner"><a href="#assert" class="scroll item">assert</a><a href="#fail" class="scroll item">fail</a><a href="#ok" class="scroll item">ok</a><a href="#notOk" class="scroll item">notOk</a><a href="#equal" class="scroll item">equal</a><a href="#notEqual" class="scroll item">notEqual</a><a href="#strictEqual" class="scroll item">strictEqual</a><a href="#notStrictEqual" class="scroll item">notStrictEqual</a><a href="#deepEqual" class="scroll item">deepEqual</a><a href="#notDeepEqual" class="scroll item">notDeepEqual</a><a href="#isTrue" class="scroll item">isTrue</a><a href="#isAbove" class="scroll item">isAbove</a><a href="#isBelow" class="scroll item">isBelow</a><a href="#isFalse" class="scroll item">isFalse</a><a href="#isNull" class="scroll item">isNull</a><a href="#isNotNull" class="scroll item">isNotNull</a><a href="#isUndefined" class="scroll item">isUndefined</a><a href="#isDefined" class="scroll item">isDefined</a><a href="#isFunction" class="scroll item">isFunction</a><a href="#isNotFunction" class="scroll item">isNotFunction</a><a href="#isObject" class="scroll item">isObject</a><a href="#isNotObject" class="scroll item">isNotObject</a><a href="#isArray" class="scroll item">isArray</a><a href="#isNotArray" class="scroll item">isNotArray</a><a href="#isString" class="scroll item">isString</a><a href="#isNotString" class="scroll item">isNotString</a><a href="#isNumber" class="scroll item">isNumber</a><a href="#isNotNumber" class="scroll item">isNotNumber</a><a href="#isBoolean" class="scroll item">isBoolean</a><a href="#isNotBoolean" class="scroll item">isNotBoolean</a><a href="#typeOf" class="scroll item">typeOf</a><a href="#notTypeOf" class="scroll item">notTypeOf</a><a href="#instanceOf" class="scroll item">instanceOf</a><a href="#notInstanceOf" class="scroll item">notInstanceOf</a><a href="#include" class="scroll item">include</a><a href="#notInclude" class="scroll item">notInclude</a><a href="#match" class="scroll item">match</a><a href="#notMatch" class="scroll item">notMatch</a><a href="#property" class="scroll item">property</a><a href="#notProperty" class="scroll item">notProperty</a><a href="#deepProperty" class="scroll item">deepProperty</a><a href="#notDeepProperty" class="scroll item">notDeepProperty</a><a href="#propertyVal" class="scroll item">propertyVal</a><a href="#propertyNotVal" class="scroll item">propertyNotVal</a><a href="#deepPropertyVal" class="scroll item">deepPropertyVal</a><a href="#deepPropertyNotVal" class="scroll item">deepPropertyNotVal</a><a href="#lengthOf" class="scroll item">lengthOf</a><a href="#throws" class="scroll item">throws / throw / Throw</a><a href="#doesNotThrow" class="scroll item">doesNotThrow</a><a href="#operator" class="scroll item">operator</a><a href="#closeTo" class="scroll item">closeTo</a><a href="#sameMembers" class="scroll item">sameMembers</a><a href="#sameDeepMembers" class="scroll item">sameDeepMembers</a><a href="#includeMembers" class="scroll item">includeMembers</a><a href="#changes" class="scroll item">changes</a><a href="#doesNotChange" class="scroll item">doesNotChange</a><a href="#increases" class="scroll item">increases</a><a href="#doesNotIncrease" class="scroll item">doesNotIncrease</a><a href="#decreases" class="scroll item">decreases</a><a href="#doesNotDecrease" class="scroll item">doesNotDecrease</a>
+                <div class="box-inner"><a href="#assert" class="scroll item">assert</a><a href="#fail" class="scroll item">fail</a><a href="#isOk" class="scroll item">isOk / ok</a><a href="#isNotOk" class="scroll item">isNotOk / notOk</a><a href="#equal" class="scroll item">equal</a><a href="#notEqual" class="scroll item">notEqual</a><a href="#strictEqual" class="scroll item">strictEqual</a><a href="#notStrictEqual" class="scroll item">notStrictEqual</a><a href="#deepEqual" class="scroll item">deepEqual</a><a href="#notDeepEqual" class="scroll item">notDeepEqual</a><a href="#isAbove" class="scroll item">isAbove</a><a href="#isAtLeast" class="scroll item">isAtLeast</a><a href="#isBelow" class="scroll item">isBelow</a><a href="#isAtMost" class="scroll item">isAtMost</a><a href="#isTrue" class="scroll item">isTrue</a><a href="#isNotTrue" class="scroll item">isNotTrue</a><a href="#isFalse" class="scroll item">isFalse</a><a href="#isNotFalse" class="scroll item">isNotFalse</a><a href="#isNull" class="scroll item">isNull</a><a href="#isNotNull" class="scroll item">isNotNull</a><a href="#isNaN" class="scroll item">isNaN</a><a href="#isNotNaN" class="scroll item">isNotNaN</a><a href="#isUndefined" class="scroll item">isUndefined</a><a href="#isDefined" class="scroll item">isDefined</a><a href="#isFunction" class="scroll item">isFunction</a><a href="#isNotFunction" class="scroll item">isNotFunction</a><a href="#isObject" class="scroll item">isObject</a><a href="#isNotObject" class="scroll item">isNotObject</a><a href="#isArray" class="scroll item">isArray</a><a href="#isNotArray" class="scroll item">isNotArray</a><a href="#isString" class="scroll item">isString</a><a href="#isNotString" class="scroll item">isNotString</a><a href="#isNumber" class="scroll item">isNumber</a><a href="#isNotNumber" class="scroll item">isNotNumber</a><a href="#isBoolean" class="scroll item">isBoolean</a><a href="#isNotBoolean" class="scroll item">isNotBoolean</a><a href="#typeOf" class="scroll item">typeOf</a><a href="#notTypeOf" class="scroll item">notTypeOf</a><a href="#instanceOf" class="scroll item">instanceOf</a><a href="#notInstanceOf" class="scroll item">notInstanceOf</a><a href="#include" class="scroll item">include</a><a href="#notInclude" class="scroll item">notInclude</a><a href="#match" class="scroll item">match</a><a href="#notMatch" class="scroll item">notMatch</a><a href="#property" class="scroll item">property</a><a href="#notProperty" class="scroll item">notProperty</a><a href="#deepProperty" class="scroll item">deepProperty</a><a href="#notDeepProperty" class="scroll item">notDeepProperty</a><a href="#propertyVal" class="scroll item">propertyVal</a><a href="#propertyNotVal" class="scroll item">propertyNotVal</a><a href="#deepPropertyVal" class="scroll item">deepPropertyVal</a><a href="#deepPropertyNotVal" class="scroll item">deepPropertyNotVal</a><a href="#lengthOf" class="scroll item">lengthOf</a><a href="#throws" class="scroll item">throws / throw / Throw</a><a href="#doesNotThrow" class="scroll item">doesNotThrow</a><a href="#operator" class="scroll item">operator</a><a href="#closeTo" class="scroll item">closeTo</a><a href="#approximately" class="scroll item">approximately</a><a href="#sameMembers" class="scroll item">sameMembers</a><a href="#sameDeepMembers" class="scroll item">sameDeepMembers</a><a href="#includeMembers" class="scroll item">includeMembers</a><a href="#oneOf" class="scroll item">oneOf</a><a href="#changes" class="scroll item">changes</a><a href="#doesNotChange" class="scroll item">doesNotChange</a><a href="#increases" class="scroll item">increases</a><a href="#doesNotIncrease" class="scroll item">doesNotIncrease</a><a href="#decreases" class="scroll item">decreases</a><a href="#doesNotDecrease" class="scroll item">doesNotDecrease</a><a href="#isExtensible" class="scroll item">isExtensible / extensible</a><a href="#isNotExtensible" class="scroll item">isNotExtensible / notExtensible</a><a href="#isSealed" class="scroll item">isSealed / sealed</a><a href="#isNotSealed" class="scroll item">isNotSealed / notSealed</a><a href="#isFrozen" class="scroll item">isFrozen / frozen</a><a href="#isNotFrozen" class="scroll item">isNotFrozen / notFrozen</a>
                 </div>
               </div>
             </div>
@@ -95,28 +95,28 @@ assert(Array.isArray([]), <span class="string">'empty arrays are arrays'</span>)
                 <div class="description"><p>Throw a failure. Node.js <code>assert</code> module-compatible.</p>
 </div>
               </div>
-              <div id="ok-section" class="segment">
-                <div class="summary"><h3 id="-ok-object-message-">.ok(object, [message])</h3>
+              <div id="isOk-section" class="segment">
+                <div class="summary"><h3 id="-isok-object-message-">.isOk(object, [message])</h3>
 </div>
                 <ul class="tags">
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">object</span><span class="desc">to test</span></li>
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
                 </ul>
                 <div class="description"><p>Asserts that <code>object</code> is truthy.</p>
-<pre><code>assert.ok(<span class="string">'everything'</span>, <span class="string">'everything is ok'</span>);
-assert.ok(<span class="literal">false</span>, <span class="string">'this will fail'</span>);</code></pre>
+<pre><code>assert.isOk(<span class="string">'everything'</span>, <span class="string">'everything is ok'</span>);
+assert.isOk(<span class="literal">false</span>, <span class="string">'this will fail'</span>);</code></pre>
 </div>
               </div>
-              <div id="notOk-section" class="segment">
-                <div class="summary"><h3 id="-notok-object-message-">.notOk(object, [message])</h3>
+              <div id="isNotOk-section" class="segment">
+                <div class="summary"><h3 id="-isnotok-object-message-">.isNotOk(object, [message])</h3>
 </div>
                 <ul class="tags">
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">object</span><span class="desc">to test</span></li>
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
                 </ul>
                 <div class="description"><p>Asserts that <code>object</code> is falsy.</p>
-<pre><code>assert.notOk(<span class="string">'everything'</span>, <span class="string">'this will fail'</span>);
-assert.notOk(<span class="literal">false</span>, <span class="string">'this will pass'</span>);</code></pre>
+<pre><code>assert.isNotOk(<span class="string">'everything'</span>, <span class="string">'this will fail'</span>);
+assert.isNotOk(<span class="literal">false</span>, <span class="string">'this will pass'</span>);</code></pre>
 </div>
               </div>
               <div id="equal-section" class="segment">
@@ -191,18 +191,6 @@ assert.notOk(<span class="literal">false</span>, <span class="string">'this will
 <pre><code>assert.notDeepEqual({ tea: <span class="string">'green'</span> }, { tea: <span class="string">'jasmine'</span> });</code></pre>
 </div>
               </div>
-              <div id="isTrue-section" class="segment">
-                <div class="summary"><h3 id="-istrue-value-message-">.isTrue(value, [message])</h3>
-</div>
-                <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
-                </ul>
-                <div class="description"><p>Asserts that <code>value</code> is true.</p>
-<pre><code><span class="keyword">var</span> teaServed = <span class="literal">true</span>;
-assert.isTrue(teaServed, <span class="string">'the tea has been served'</span>);</code></pre>
-</div>
-              </div>
               <div id="isAbove-section" class="segment">
                 <div class="summary"><h3 id="-isabove-valuetocheck-valuetobeabove-message-">.isAbove(valueToCheck, valueToBeAbove, [message])</h3>
 </div>
@@ -213,6 +201,19 @@ assert.isTrue(teaServed, <span class="string">'the tea has been served'</span>);
                 </ul>
                 <div class="description"><p>Asserts <code>valueToCheck</code> is strictly greater than (&gt;) <code>valueToBeAbove</code></p>
 <pre><code>assert.isAbove(<span class="number">5</span>, <span class="number">2</span>, <span class="string">'5 is strictly greater than 2'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isAtLeast-section" class="segment">
+                <div class="summary"><h3 id="-isatleast-valuetocheck-valuetobeatleast-message-">.isAtLeast(valueToCheck, valueToBeAtLeast, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">valueToCheck</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">valueToBeAtLeast</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts <code>valueToCheck</code> is greater than or equal to (&gt;=) <code>valueToBeAtLeast</code></p>
+<pre><code>assert.isAtLeast(<span class="number">5</span>, <span class="number">2</span>, <span class="string">'5 is greater or equal to 2'</span>);
+assert.isAtLeast(<span class="number">3</span>, <span class="number">3</span>, <span class="string">'3 is greater or equal to 3'</span>);</code></pre>
 </div>
               </div>
               <div id="isBelow-section" class="segment">
@@ -227,6 +228,43 @@ assert.isTrue(teaServed, <span class="string">'the tea has been served'</span>);
 <pre><code>assert.isBelow(<span class="number">3</span>, <span class="number">6</span>, <span class="string">'3 is strictly less than 6'</span>);</code></pre>
 </div>
               </div>
+              <div id="isAtMost-section" class="segment">
+                <div class="summary"><h3 id="-isatmost-valuetocheck-valuetobeatmost-message-">.isAtMost(valueToCheck, valueToBeAtMost, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">valueToCheck</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">valueToBeAtMost</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts <code>valueToCheck</code> is less than or equal to (&lt;=) <code>valueToBeAtMost</code></p>
+<pre><code>assert.isAtMost(<span class="number">3</span>, <span class="number">6</span>, <span class="string">'3 is less than or equal to 6'</span>);
+assert.isAtMost(<span class="number">4</span>, <span class="number">4</span>, <span class="string">'4 is less than or equal to 4'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isTrue-section" class="segment">
+                <div class="summary"><h3 id="-istrue-value-message-">.isTrue(value, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>value</code> is true.</p>
+<pre><code><span class="keyword">var</span> teaServed = <span class="literal">true</span>;
+assert.isTrue(teaServed, <span class="string">'the tea has been served'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isNotTrue-section" class="segment">
+                <div class="summary"><h3 id="-isnottrue-value-message-">.isNotTrue(value, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>value</code> is not true.</p>
+<pre><code><span class="keyword">var</span> tea = <span class="string">'tasty chai'</span>;
+assert.isNotTrue(tea, <span class="string">'great, time for tea!'</span>);</code></pre>
+</div>
+              </div>
               <div id="isFalse-section" class="segment">
                 <div class="summary"><h3 id="-isfalse-value-message-">.isFalse(value, [message])</h3>
 </div>
@@ -237,6 +275,18 @@ assert.isTrue(teaServed, <span class="string">'the tea has been served'</span>);
                 <div class="description"><p>Asserts that <code>value</code> is false.</p>
 <pre><code><span class="keyword">var</span> teaServed = <span class="literal">false</span>;
 assert.isFalse(teaServed, <span class="string">'no tea yet? hmm...'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isNotFalse-section" class="segment">
+                <div class="summary"><h3 id="-isnotfalse-value-message-">.isNotFalse(value, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>value</code> is not false.</p>
+<pre><code><span class="keyword">var</span> tea = <span class="string">'tasty chai'</span>;
+assert.isNotFalse(tea, <span class="string">'great, time for tea!'</span>);</code></pre>
 </div>
               </div>
               <div id="isNull-section" class="segment">
@@ -260,6 +310,28 @@ assert.isFalse(teaServed, <span class="string">'no tea yet? hmm...'</span>);</co
                 <div class="description"><p>Asserts that <code>value</code> is not null.</p>
 <pre><code><span class="keyword">var</span> tea = <span class="string">'tasty chai'</span>;
 assert.isNotNull(tea, <span class="string">'great, time for tea!'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isNaN-section" class="segment">
+                <div class="summary"><h3 id="-isnan">.isNaN</h3>
+<p>Asserts that value is NaN</p>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>   assert.isNaN(&#39;foo&#39;, &#39;foo is NaN&#39;);</p>
+</div>
+              </div>
+              <div id="isNotNaN-section" class="segment">
+                <div class="summary"><h3 id="-isnotnan">.isNotNaN</h3>
+<p>Asserts that value is not NaN</p>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">value</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>   assert.isNotNaN(4, &#39;4 is not NaN&#39;);</p>
 </div>
               </div>
               <div id="isUndefined-section" class="segment">
@@ -522,10 +594,9 @@ assert.include([ <span class="number">1</span>, <span class="number">2</span>, <
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
                 </ul>
                 <div class="description"><p>Asserts that <code>haystack</code> does not include <code>needle</code>. Works
-for strings and arrays.
-i
-    assert.notInclude(&#39;foobar&#39;, &#39;baz&#39;, &#39;string not include substring&#39;);
-    assert.notInclude([ 1, 2, 3 ], 4, &#39;array not include contain value&#39;);</p>
+for strings and arrays.</p>
+<pre><code>assert.notInclude(<span class="string">'foobar'</span>, <span class="string">'baz'</span>, <span class="string">'string not include substring'</span>);
+assert.notInclude([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ], <span class="number">4</span>, <span class="string">'array not include contain value'</span>);</code></pre>
 </div>
               </div>
               <div id="match-section" class="segment">
@@ -670,7 +741,7 @@ bracket-notation for deep reference.</p>
                 </ul>
                 <div class="description"><p>Asserts that <code>object</code> has a <code>length</code> property with the expected value.</p>
 <pre><code>assert.lengthOf([<span class="number">1</span>,<span class="number">2</span>,<span class="number">3</span>], <span class="number">3</span>, <span class="string">'array has length of 3'</span>);
-assert.lengthOf(<span class="string">'foobar'</span>, <span class="number">5</span>, <span class="string">'string has length of 6'</span>);</code></pre>
+assert.lengthOf(<span class="string">'foobar'</span>, <span class="number">6</span>, <span class="string">'string has length of 6'</span>);</code></pre>
 </div>
               </div>
               <div id="throws-section" class="segment">
@@ -687,11 +758,11 @@ assert.lengthOf(<span class="string">'foobar'</span>, <span class="number">5</sp
                 <div class="description"><p>Asserts that <code>function</code> will throw an error that is an instance of
 <code>constructor</code>, or alternately that it will throw an error with message
 matching <code>regexp</code>.</p>
-<pre><code>assert.<span class="keyword">throw</span>(fn, <span class="string">'function throws a reference error'</span>);
-assert.<span class="keyword">throw</span>(fn, <span class="regexp">/function throws a reference error/</span>);
-assert.<span class="keyword">throw</span>(fn, ReferenceError);
-assert.<span class="keyword">throw</span>(fn, ReferenceError, <span class="string">'function throws a reference error'</span>);
-assert.<span class="keyword">throw</span>(fn, ReferenceError, <span class="regexp">/function throws a reference error/</span>);</code></pre>
+<pre><code>assert.throws(fn, <span class="string">'function throws a reference error'</span>);
+assert.throws(fn, <span class="regexp">/function throws a reference error/</span>);
+assert.throws(fn, ReferenceError);
+assert.throws(fn, ReferenceError, <span class="string">'function throws a reference error'</span>);
+assert.throws(fn, ReferenceError, <span class="regexp">/function throws a reference error/</span>);</code></pre>
 </div>
               </div>
               <div id="doesNotThrow-section" class="segment">
@@ -738,6 +809,19 @@ assert.operator(<span class="number">1</span>, <span class="string">'>'</span>, 
 <pre><code>assert.closeTo(<span class="number">1.5</span>, <span class="number">1</span>, <span class="number">0.5</span>, <span class="string">'numbers are close'</span>);</code></pre>
 </div>
               </div>
+              <div id="approximately-section" class="segment">
+                <div class="summary"><h3 id="-approximately-actual-expected-delta-message-">.approximately(actual, expected, delta, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Number &#125;</span><span class="name">actual</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Number &#125;</span><span class="name">expected</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Number &#125;</span><span class="name">delta</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts that the target is equal <code>expected</code>, to within a +/- <code>delta</code> range.</p>
+<pre><code>assert.approximately(<span class="number">1.5</span>, <span class="number">1</span>, <span class="number">0.5</span>, <span class="string">'numbers are close'</span>);</code></pre>
+</div>
+              </div>
               <div id="sameMembers-section" class="segment">
                 <div class="summary"><h3 id="-samemembers-set1-set2-message-">.sameMembers(set1, set2, [message])</h3>
 </div>
@@ -775,6 +859,18 @@ Order is not taken into account.</p>
                 <div class="description"><p>Asserts that <code>subset</code> is included in <code>superset</code>.
 Order is not taken into account.</p>
 <pre><code>assert.includeMembers([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ], [ <span class="number">2</span>, <span class="number">1</span> ], <span class="string">'include members'</span>);</code></pre>
+</div>
+              </div>
+              <div id="oneOf-section" class="segment">
+                <div class="summary"><h3 id="-oneof-inlist-list-message-">.oneOf(inList, list, [message])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; * &#125;</span><span class="name">inList</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Array&lt;*&gt; &#125;</span><span class="name">list</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc"></span></li>
+                </ul>
+                <div class="description"><p>Asserts that non-object, non-array value <code>inList</code> appears in the flat array <code>list</code>.</p>
+<pre><code>assert.oneOf(<span class="number">1</span>, [ <span class="number">2</span>, <span class="number">1</span> ], <span class="string">'Not found in list'</span>);</code></pre>
 </div>
               </div>
               <div id="changes-section" class="segment">
@@ -865,6 +961,85 @@ assert.decreases(fn, obj, <span class="string">'val'</span>);</code></pre>
 <pre><code><span class="keyword">var</span> obj = { val: <span class="number">10</span> };
 <span class="keyword">var</span> fn = <span class="keyword">function</span>() { obj.val = <span class="number">15</span> };
 assert.doesNotDecrease(fn, obj, <span class="string">'val'</span>);</code></pre>
+</div>
+              </div>
+              <div id="isExtensible-section" class="segment">
+                <div class="summary"><h3 id="-isextensible-object-">.isExtensible(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is extensible (can have new properties added to it).</p>
+<pre><code>assert.isExtensible({});</code></pre>
+</div>
+              </div>
+              <div id="isNotExtensible-section" class="segment">
+                <div class="summary"><h3 id="-isnotextensible-object-">.isNotExtensible(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is <em>not</em> extensible.</p>
+<pre><code><span class="keyword">var</span> nonExtensibleObject = Object.preventExtensions({});
+<span class="keyword">var</span> sealedObject = Object.seal({});
+<span class="keyword">var</span> frozenObject = Object.freese({});
+
+assert.isNotExtensible(nonExtensibleObject);
+assert.isNotExtensible(sealedObject);
+assert.isNotExtensible(frozenObject);</code></pre>
+</div>
+              </div>
+              <div id="isSealed-section" class="segment">
+                <div class="summary"><h3 id="-issealed-object-">.isSealed(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is sealed (cannot have new properties added to it
+and its existing properties cannot be removed).</p>
+<pre><code><span class="keyword">var</span> sealedObject = Object.seal({});
+<span class="keyword">var</span> frozenObject = Object.seal({});
+
+assert.isSealed(sealedObject);
+assert.isSealed(frozenObject);</code></pre>
+</div>
+              </div>
+              <div id="isNotSealed-section" class="segment">
+                <div class="summary"><h3 id="-isnotsealed-object-">.isNotSealed(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is <em>not</em> sealed.</p>
+<pre><code>assert.isNotSealed({});</code></pre>
+</div>
+              </div>
+              <div id="isFrozen-section" class="segment">
+                <div class="summary"><h3 id="-isfrozen-object-">.isFrozen(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is frozen (cannot have new properties added to it
+and its existing properties cannot be modified).</p>
+<pre><code><span class="keyword">var</span> frozenObject = Object.freeze({});
+assert.frozen(frozenObject);</code></pre>
+</div>
+              </div>
+              <div id="isNotFrozen-section" class="segment">
+                <div class="summary"><h3 id="-isnotfrozen-object-">.isNotFrozen(object)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that <code>object</code> is <em>not</em> frozen.</p>
+<pre><code>assert.isNotFrozen({});</code></pre>
 </div>
               </div>
             </div>

--- a/out/api/bdd/index.html
+++ b/out/api/bdd/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?3.4.2"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -56,7 +56,7 @@
           <div class="list box-wrap antiscroll-wrap">
             <div class="box">
               <div class="antiscroll-inner">
-                <div class="box-inner"><a href="#language-chains" class="scroll item">language chains</a><a href="#not" class="scroll item">not</a><a href="#deep" class="scroll item">deep</a><a href="#any" class="scroll item">any</a><a href="#all" class="scroll item">all</a><a href="#a" class="scroll item">a / an</a><a href="#include" class="scroll item">include / contain / includes / contains</a><a href="#ok" class="scroll item">ok</a><a href="#true" class="scroll item">true</a><a href="#false" class="scroll item">false</a><a href="#null" class="scroll item">null</a><a href="#undefined" class="scroll item">undefined</a><a href="#exist" class="scroll item">exist</a><a href="#empty" class="scroll item">empty</a><a href="#arguments" class="scroll item">arguments / Arguments</a><a href="#equal" class="scroll item">equal / equals / eq / deep.equal</a><a href="#eql" class="scroll item">eql / eqls</a><a href="#above" class="scroll item">above / gt / greaterThan</a><a href="#least" class="scroll item">least / gte</a><a href="#below" class="scroll item">below / lt / lessThan</a><a href="#most" class="scroll item">most / lte</a><a href="#within" class="scroll item">within</a><a href="#instanceof" class="scroll item">instanceof / instanceOf</a><a href="#property" class="scroll item">property / deep.property</a><a href="#ownProperty" class="scroll item">ownProperty / haveOwnProperty</a><a href="#length" class="scroll item">length / lengthOf</a><a href="#match" class="scroll item">match</a><a href="#string" class="scroll item">string</a><a href="#keys" class="scroll item">keys / key</a><a href="#throw" class="scroll item">throw / throws / Throw</a><a href="#respondTo" class="scroll item">respondTo</a><a href="#itself" class="scroll item">itself</a><a href="#satisfy" class="scroll item">satisfy</a><a href="#closeTo" class="scroll item">closeTo</a><a href="#members" class="scroll item">members</a><a href="#change" class="scroll item">change / changes / Change</a><a href="#increase" class="scroll item">increase / increases / Increase</a><a href="#decrease" class="scroll item">decrease / decreases / Decrease</a>
+                <div class="box-inner"><a href="#language-chains" class="scroll item">language chains</a><a href="#not" class="scroll item">not</a><a href="#deep" class="scroll item">deep</a><a href="#any" class="scroll item">any</a><a href="#all" class="scroll item">all</a><a href="#a" class="scroll item">a / an</a><a href="#include" class="scroll item">include / contain / includes / contains</a><a href="#ok" class="scroll item">ok</a><a href="#true" class="scroll item">true</a><a href="#false" class="scroll item">false</a><a href="#null" class="scroll item">null</a><a href="#undefined" class="scroll item">undefined</a><a href="#NaN" class="scroll item">NaN</a><a href="#exist" class="scroll item">exist</a><a href="#empty" class="scroll item">empty</a><a href="#arguments" class="scroll item">arguments / Arguments</a><a href="#equal" class="scroll item">equal / equals / eq / deep.equal</a><a href="#eql" class="scroll item">eql / eqls</a><a href="#above" class="scroll item">above / gt / greaterThan</a><a href="#least" class="scroll item">least / gte</a><a href="#below" class="scroll item">below / lt / lessThan</a><a href="#most" class="scroll item">most / lte</a><a href="#within" class="scroll item">within</a><a href="#instanceof" class="scroll item">instanceof / instanceOf</a><a href="#property" class="scroll item">property / deep.property</a><a href="#ownProperty" class="scroll item">ownProperty / haveOwnProperty</a><a href="#ownPropertyDescriptor" class="scroll item">ownPropertyDescriptor / haveOwnPropertyDescriptor</a><a href="#length" class="scroll item">length</a><a href="#lengthOf" class="scroll item">lengthOf</a><a href="#match" class="scroll item">match / matches</a><a href="#string" class="scroll item">string</a><a href="#keys" class="scroll item">keys / key</a><a href="#throw" class="scroll item">throw / throws / Throw</a><a href="#respondTo" class="scroll item">respondTo / respondsTo</a><a href="#itself" class="scroll item">itself</a><a href="#satisfy" class="scroll item">satisfy / satisfies</a><a href="#closeTo" class="scroll item">closeTo / approximately</a><a href="#members" class="scroll item">members</a><a href="#oneOf" class="scroll item">oneOf</a><a href="#change" class="scroll item">change / changes / Change</a><a href="#increase" class="scroll item">increase / increases / Increase</a><a href="#decrease" class="scroll item">decrease / decreases / Decrease</a><a href="#extensible" class="scroll item">extensible</a><a href="#sealed" class="scroll item">sealed</a><a href="#frozen" class="scroll item">frozen</a>
                 </div>
               </div>
             </div>
@@ -120,6 +120,10 @@ expect({ foo: <span class="string">'baz'</span> }).to.have.property(<span class=
 <pre><code>expect(foo).to.deep.equal({ bar: <span class="string">'baz'</span> });
 expect({ foo: { bar: { baz: <span class="string">'quux'</span> } } })
   .to.have.deep.property(<span class="string">'foo.bar.baz'</span>, <span class="string">'quux'</span>);</code></pre>
+<p><code>.deep.property</code> special characters can be escaped
+by adding two slashes before the <code>.</code> or <code>[]</code>.</p>
+<pre><code><span class="keyword">var</span> deepCss = { <span class="string">'.link'</span>: { <span class="string">'[target]'</span>: <span class="number">42</span> }};
+expect(deepCss).to.have.deep.property(<span class="string">'\\.link.\\[target\\]'</span>, <span class="number">42</span>);</code></pre>
 </div>
               </div>
               <div id="any-section" class="segment">
@@ -128,7 +132,7 @@ expect({ foo: { bar: { baz: <span class="string">'quux'</span> } } })
                 <ul class="tags">
                 </ul>
                 <div class="description"><p>Sets the <code>any</code> flag, (opposite of the <code>all</code> flag)
-later used in the <code>keys</code> assertion. </p>
+later used in the <code>keys</code> assertion.</p>
 <pre><code>expect(foo).to.have.any.keys(<span class="string">'bar'</span>, <span class="string">'baz'</span>);</code></pre>
 </div>
               </div>
@@ -137,7 +141,7 @@ later used in the <code>keys</code> assertion. </p>
 </div>
                 <ul class="tags">
                 </ul>
-                <div class="description"><p>Sets the <code>all</code> flag (opposite of the <code>any</code> flag) 
+                <div class="description"><p>Sets the <code>all</code> flag (opposite of the <code>any</code> flag)
 later used by the <code>keys</code> assertion.</p>
 <pre><code>expect(foo).to.have.all.keys(<span class="string">'bar'</span>, <span class="string">'baz'</span>);</code></pre>
 </div>
@@ -157,6 +161,13 @@ expect(<span class="string">'test'</span>).to.be.a(<span class="string">'string'
 expect({ foo: <span class="string">'bar'</span> }).to.be.an(<span class="string">'object'</span>);
 expect(<span class="literal">null</span>).to.be.a(<span class="string">'null'</span>);
 expect(undefined).to.be.an(<span class="string">'undefined'</span>);
+expect(<span class="keyword">new</span> Error).to.be.an(<span class="string">'error'</span>);
+expect(<span class="keyword">new</span> Promise).to.be.a(<span class="string">'promise'</span>);
+expect(<span class="keyword">new</span> Float32Array()).to.be.a(<span class="string">'float32array'</span>);
+expect(Symbol()).to.be.a(<span class="string">'symbol'</span>);
+
+<span class="comment">// es6 overrides</span>
+expect({[Symbol.toStringTag]:()=><span class="string">'foo'</span>}).to.be.a(<span class="string">'foo'</span>);
 
 <span class="comment">// language chain</span>
 expect(foo).to.be.an.<span class="keyword">instanceof</span>(Foo);</code></pre>
@@ -184,7 +195,7 @@ expect({ foo: <span class="string">'bar'</span>, hello: <span class="string">'un
                 <ul class="tags">
                 </ul>
                 <div class="description"><p>Asserts that the target is truthy.</p>
-<pre><code>expect(<span class="string">'everthing'</span>).to.be.ok;
+<pre><code>expect(<span class="string">'everything'</span>).to.be.ok;
 expect(<span class="number">1</span>).to.be.ok;
 expect(<span class="literal">false</span>).to.not.be.ok;
 expect(undefined).to.not.be.ok;
@@ -218,7 +229,7 @@ expect(<span class="number">0</span>).to.not.be.<span class="literal">false</spa
                 </ul>
                 <div class="description"><p>Asserts that the target is <code>null</code>.</p>
 <pre><code>expect(<span class="literal">null</span>).to.be.<span class="literal">null</span>;
-expect(undefined).not.to.be.<span class="literal">null</span>;</code></pre>
+expect(undefined).to.not.be.<span class="literal">null</span>;</code></pre>
 </div>
               </div>
               <div id="undefined-section" class="segment">
@@ -229,6 +240,16 @@ expect(undefined).not.to.be.<span class="literal">null</span>;</code></pre>
                 <div class="description"><p>Asserts that the target is <code>undefined</code>.</p>
 <pre><code>expect(undefined).to.be.undefined;
 expect(<span class="literal">null</span>).to.not.be.undefined;</code></pre>
+</div>
+              </div>
+              <div id="NaN-section" class="segment">
+                <div class="summary"><h3 id="-nan">.NaN</h3>
+<p>Asserts that the target is <code>NaN</code>.</p>
+</div>
+                <ul class="tags">
+                </ul>
+                <div class="description"><pre><code>expect(<span class="string">'foo'</span>).to.be.NaN;
+expect(<span class="number">4</span>).not.to.be.NaN;</code></pre>
 </div>
               </div>
               <div id="exist-section" class="segment">
@@ -251,7 +272,7 @@ expect(baz).to.not.exist;</code></pre>
 </div>
                 <ul class="tags">
                 </ul>
-                <div class="description"><p>Asserts that the target&#39;s length is <code>0</code>. For arrays, it checks
+                <div class="description"><p>Asserts that the target&#39;s length is <code>0</code>. For arrays and strings, it checks
 the <code>length</code> property. For objects, it gets the count of
 enumerable keys.</p>
 <pre><code>expect([]).to.be.empty;
@@ -449,6 +470,16 @@ expect(deepObj).to.have.property(<span class="string">'teas'</span>)
   .that.is.an(<span class="string">'array'</span>)
   .<span class="keyword">with</span>.deep.property(<span class="string">'[2]'</span>)
     .that.deep.equals({ tea: <span class="string">'konacha'</span> });</code></pre>
+<p>Note that dots and bracket in <code>name</code> must be backslash-escaped when
+the <code>deep</code> flag is set, while they must NOT be escaped when the <code>deep</code>
+flag is not set.</p>
+<pre><code><span class="comment">// simple referencing</span>
+<span class="keyword">var</span> css = { <span class="string">'.link[target]'</span>: <span class="number">42</span> };
+expect(css).to.have.property(<span class="string">'.link[target]'</span>, <span class="number">42</span>);
+
+<span class="comment">// deep referencing</span>
+<span class="keyword">var</span> deepCss = { <span class="string">'.link'</span>: { <span class="string">'[target]'</span>: <span class="number">42</span> }};
+expect(deepCss).to.have.deep.property(<span class="string">'\\.link.\\[target\\]'</span>, <span class="number">42</span>);</code></pre>
 </div>
               </div>
               <div id="ownProperty-section" class="segment">
@@ -462,8 +493,43 @@ expect(deepObj).to.have.property(<span class="string">'teas'</span>)
 <pre><code>expect(<span class="string">'test'</span>).to.have.ownProperty(<span class="string">'length'</span>);</code></pre>
 </div>
               </div>
+              <div id="ownPropertyDescriptor-section" class="segment">
+                <div class="summary"><h3 id="-ownpropertydescriptor-name-descriptor-message-">.ownPropertyDescriptor(name[, descriptor[, message]])</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">name</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">descriptor</span><span class="desc">_optional_</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Asserts that the target has an own property descriptor <code>name</code>, that optionally matches <code>descriptor</code>.</p>
+<pre><code>expect(<span class="string">'test'</span>).to.have.ownPropertyDescriptor(<span class="string">'length'</span>);
+expect(<span class="string">'test'</span>).to.have.ownPropertyDescriptor(<span class="string">'length'</span>, { enumerable: <span class="literal">false</span>, configurable: <span class="literal">false</span>, writable: <span class="literal">false</span>, value: <span class="number">4</span> });
+expect(<span class="string">'test'</span>).not.to.have.ownPropertyDescriptor(<span class="string">'length'</span>, { enumerable: <span class="literal">false</span>, configurable: <span class="literal">false</span>, writable: <span class="literal">false</span>, value: <span class="number">3</span> });
+expect(<span class="string">'test'</span>).ownPropertyDescriptor(<span class="string">'length'</span>).to.have.property(<span class="string">'enumerable'</span>, <span class="literal">false</span>);
+expect(<span class="string">'test'</span>).ownPropertyDescriptor(<span class="string">'length'</span>).to.have.keys(<span class="string">'value'</span>);</code></pre>
+</div>
+              </div>
               <div id="length-section" class="segment">
-                <div class="summary"><h3 id="-length-value-">.length(value)</h3>
+                <div class="summary"><h3 id="-length">.length</h3>
+</div>
+                <ul class="tags">
+                </ul>
+                <div class="description"><p>Sets the <code>doLength</code> flag later used as a chain precursor to a value
+comparison for the <code>length</code> property.</p>
+<pre><code>expect(<span class="string">'foo'</span>).to.have.length.above(<span class="number">2</span>);
+expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.above(<span class="number">2</span>);
+expect(<span class="string">'foo'</span>).to.have.length.below(<span class="number">4</span>);
+expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.below(<span class="number">4</span>);
+expect(<span class="string">'foo'</span>).to.have.length.within(<span class="number">2</span>,<span class="number">4</span>);
+expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.within(<span class="number">2</span>,<span class="number">4</span>);</code></pre>
+<p><em>Deprecation notice:</em> Using <code>length</code> as an assertion will be deprecated
+in version 2.4.0 and removed in 3.0.0. Code using the old style of
+asserting for <code>length</code> property value using <code>length(value)</code> should be
+switched to use <code>lengthOf(value)</code> instead.</p>
+</div>
+              </div>
+              <div id="lengthOf-section" class="segment">
+                <div class="summary"><h3 id="-lengthof-value-message-">.lengthOf(value[, message])</h3>
 </div>
                 <ul class="tags">
                   <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Number &#125;</span><span class="name">length</span><span class="desc"></span></li>
@@ -471,16 +537,8 @@ expect(deepObj).to.have.property(<span class="string">'teas'</span>)
                 </ul>
                 <div class="description"><p>Asserts that the target&#39;s <code>length</code> property has
 the expected value.</p>
-<pre><code>expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span>]).to.have.length(<span class="number">3</span>);
-expect(<span class="string">'foobar'</span>).to.have.length(<span class="number">6</span>);</code></pre>
-<p>Can also be used as a chain precursor to a value
-comparison for the length property.</p>
-<pre><code>expect(<span class="string">'foo'</span>).to.have.length.above(<span class="number">2</span>);
-expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.above(<span class="number">2</span>);
-expect(<span class="string">'foo'</span>).to.have.length.below(<span class="number">4</span>);
-expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.below(<span class="number">4</span>);
-expect(<span class="string">'foo'</span>).to.have.length.within(<span class="number">2</span>,<span class="number">4</span>);
-expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span> ]).to.have.length.within(<span class="number">2</span>,<span class="number">4</span>);</code></pre>
+<pre><code>expect([ <span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span>]).to.have.lengthOf(<span class="number">3</span>);
+expect(<span class="string">'foobar'</span>).to.have.lengthOf(<span class="number">6</span>);</code></pre>
 </div>
               </div>
               <div id="match-section" class="segment">
@@ -509,21 +567,21 @@ expect([ <span class="number">1</span>, <span class="number">2</span>, <span cla
                 <div class="summary"><h3 id="-keys-key1-key2-">.keys(key1, [key2], [...])</h3>
 </div>
                 <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String... | Array | Object &#125;</span><span class="name">keys</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; ...String | Array | Object &#125;</span><span class="name">keys</span><span class="desc"></span></li>
                 </ul>
                 <div class="description"><p>Asserts that the target contains any or all of the passed-in keys.
-Use in combination with <code>any</code>, <code>all</code>, <code>contains</code>, or <code>have</code> will affect 
+Use in combination with <code>any</code>, <code>all</code>, <code>contains</code>, or <code>have</code> will affect
 what will pass.</p>
-<p>When used in conjunction with <code>any</code>, at least one key that is passed 
-in must exist in the target object. This is regardless whether or not 
+<p>When used in conjunction with <code>any</code>, at least one key that is passed
+in must exist in the target object. This is regardless whether or not
 the <code>have</code> or <code>contain</code> qualifiers are used. Note, either <code>any</code> or <code>all</code>
 should be used in the assertion. If neither are used, the assertion is
 defaulted to <code>all</code>.</p>
-<p>When both <code>all</code> and <code>contain</code> are used, the target object must have at 
+<p>When both <code>all</code> and <code>contain</code> are used, the target object must have at
 least all of the passed-in keys but may have more keys not listed.</p>
 <p>When both <code>all</code> and <code>have</code> are used, the target object must both contain
 all of the passed-in keys AND the number of keys in the target object must
-match the number of keys passed in (in other words, a target object must 
+match the number of keys passed in (in other words, a target object must
 have all and only all of the passed-in keys).</p>
 <pre><code>expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.have.any.keys(<span class="string">'foo'</span>, <span class="string">'baz'</span>);
 expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.have.any.keys(<span class="string">'foo'</span>);
@@ -531,9 +589,9 @@ expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> 
 expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.contain.any.keys([<span class="string">'foo'</span>]);
 expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.contain.any.keys({<span class="string">'foo'</span>: <span class="number">6</span>});
 expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.have.all.keys([<span class="string">'bar'</span>, <span class="string">'foo'</span>]);
-expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.have.all.keys({<span class="string">'bar'</span>: <span class="number">6</span>, <span class="string">'foo'</span>, <span class="number">7</span>});
+expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span> }).to.have.all.keys({<span class="string">'bar'</span>: <span class="number">6</span>, <span class="string">'foo'</span>: <span class="number">7</span>});
 expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span>, baz: <span class="number">3</span> }).to.contain.all.keys([<span class="string">'bar'</span>, <span class="string">'foo'</span>]);
-expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span>, baz: <span class="number">3</span> }).to.contain.all.keys([{<span class="string">'bar'</span>: <span class="number">6</span>}}]);</code></pre>
+expect({ foo: <span class="number">1</span>, bar: <span class="number">2</span>, baz: <span class="number">3</span> }).to.contain.all.keys({<span class="string">'bar'</span>: <span class="number">6</span>});</code></pre>
 </div>
               </div>
               <div id="throw-section" class="segment">
@@ -556,8 +614,7 @@ expect(fn).to.<span class="keyword">throw</span>(Error);
 expect(fn).to.<span class="keyword">throw</span>(<span class="regexp">/bad function/</span>);
 expect(fn).to.not.<span class="keyword">throw</span>(<span class="string">'good function'</span>);
 expect(fn).to.<span class="keyword">throw</span>(ReferenceError, <span class="regexp">/bad function/</span>);
-expect(fn).to.<span class="keyword">throw</span>(err);
-expect(fn).to.not.<span class="keyword">throw</span>(<span class="keyword">new</span> RangeError(<span class="string">'Out of range.'</span>));</code></pre>
+expect(fn).to.<span class="keyword">throw</span>(err);</code></pre>
 <p>Please note that when a throw expectation is negated, it will check each
 parameter independently, starting with error constructor type. The appropriate way
 to check for the existence of a type of error but for a message that does not match
@@ -640,6 +697,25 @@ expect([<span class="number">5</span>, <span class="number">2</span>]).to.not.ha
 expect([{ id: <span class="number">1</span> }]).to.deep.include.members([{ id: <span class="number">1</span> }]);</code></pre>
 </div>
               </div>
+              <div id="oneOf-section" class="segment">
+                <div class="summary"><h3 id="-oneof-list-">.oneOf(list)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Array&lt;*&gt; &#125;</span><span class="name">list</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">message</span><span class="desc">_optional_</span></li>
+                </ul>
+                <div class="description"><p>Assert that a value appears somewhere in the top level of array <code>list</code>.</p>
+<pre><code>expect(<span class="string">'a'</span>).to.be.oneOf([<span class="string">'a'</span>, <span class="string">'b'</span>, <span class="string">'c'</span>]);
+expect(<span class="number">9</span>).to.not.be.oneOf([<span class="string">'z'</span>]);
+expect([<span class="number">3</span>]).to.not.be.oneOf([<span class="number">1</span>, <span class="number">2</span>, [<span class="number">3</span>]]);
+
+<span class="keyword">var</span> three = [<span class="number">3</span>];
+<span class="comment">// for object-types, contents are not compared</span>
+expect(three).to.not.be.oneOf([<span class="number">1</span>, <span class="number">2</span>, [<span class="number">3</span>]]);
+<span class="comment">// comparing references works</span>
+expect(three).to.be.oneOf([<span class="number">1</span>, <span class="number">2</span>, three]);</code></pre>
+</div>
+              </div>
               <div id="change-section" class="segment">
                 <div class="summary"><h3 id="-change-function-">.change(function)</h3>
 </div>
@@ -682,6 +758,51 @@ expect(fn).to.increase(obj, <span class="string">'val'</span>);</code></pre>
 <pre><code><span class="keyword">var</span> obj = { val: <span class="number">10</span> };
 <span class="keyword">var</span> fn = <span class="keyword">function</span>() { obj.val = <span class="number">5</span> };
 expect(fn).to.decrease(obj, <span class="string">'val'</span>);</code></pre>
+</div>
+              </div>
+              <div id="extensible-section" class="segment">
+                <div class="summary"><h3 id="-extensible">.extensible</h3>
+</div>
+                <ul class="tags">
+                </ul>
+                <div class="description"><p>Asserts that the target is extensible (can have new properties added to
+it).</p>
+<pre><code><span class="keyword">var</span> nonExtensibleObject = Object.preventExtensions({});
+<span class="keyword">var</span> sealedObject = Object.seal({});
+<span class="keyword">var</span> frozenObject = Object.freeze({});
+
+expect({}).to.be.extensible;
+expect(nonExtensibleObject).to.not.be.extensible;
+expect(sealedObject).to.not.be.extensible;
+expect(frozenObject).to.not.be.extensible;</code></pre>
+</div>
+              </div>
+              <div id="sealed-section" class="segment">
+                <div class="summary"><h3 id="-sealed">.sealed</h3>
+</div>
+                <ul class="tags">
+                </ul>
+                <div class="description"><p>Asserts that the target is sealed (cannot have new properties added to it
+and its existing properties cannot be removed).</p>
+<pre><code><span class="keyword">var</span> sealedObject = Object.seal({});
+<span class="keyword">var</span> frozenObject = Object.freeze({});
+
+expect(sealedObject).to.be.sealed;
+expect(frozenObject).to.be.sealed;
+expect({}).to.not.be.sealed;</code></pre>
+</div>
+              </div>
+              <div id="frozen-section" class="segment">
+                <div class="summary"><h3 id="-frozen">.frozen</h3>
+</div>
+                <ul class="tags">
+                </ul>
+                <div class="description"><p>Asserts that the target is frozen (cannot have new properties added to it
+and its existing properties cannot be modified).</p>
+<pre><code><span class="keyword">var</span> frozenObject = Object.freeze({});
+
+expect(frozenObject).to.be.frozen;
+expect({}).to.not.be.frozen;</code></pre>
 </div>
               </div>
             </div>

--- a/out/api/index.html
+++ b/out/api/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?3.4.2"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/api/plugins/index.html
+++ b/out/api/plugins/index.html
@@ -10,9 +10,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <script src="/public/js/main.js?3.4.2"></script>
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -56,7 +56,7 @@
           <div class="list box-wrap antiscroll-wrap">
             <div class="box">
               <div class="antiscroll-inner">
-                <div class="box-inner"><a href="#type" class="scroll item">type</a><a href="#addMethod" class="scroll item">addMethod</a><a href="#overwriteMethod" class="scroll item">overwriteMethod</a><a href="#addProperty" class="scroll item">addProperty</a><a href="#overwriteProperty" class="scroll item">overwriteProperty</a><a href="#overwriteChainableMethod" class="scroll item">overwriteChainableMethod</a><a href="#flag" class="scroll item">flag</a><a href="#transferFlags" class="scroll item">transferFlags</a><a href="#getPathValue" class="scroll item">getPathValue</a><a href="#addChainableMethod" class="scroll item">addChainableMethod</a>
+                <div class="box-inner"><a href="#getPathValue" class="scroll item">getPathValue</a><a href="#assert" class="scroll item">assert</a><a href="#addMethod" class="scroll item">addMethod</a><a href="#overwriteMethod" class="scroll item">overwriteMethod</a><a href="#addProperty" class="scroll item">addProperty</a><a href="#addChainableMethod" class="scroll item">addChainableMethod</a><a href="#overwriteChainableMethod" class="scroll item">overwriteChainableMethod</a><a href="#flag" class="scroll item">flag</a><a href="#transferFlags" class="scroll item">transferFlags</a><a href="#overwriteProperty" class="scroll item">overwriteProperty</a>
                 </div>
               </div>
             </div>
@@ -72,19 +72,43 @@ assertions. The <a href="/guide/plugins">Code Plugin Concepts</a> and
 how to get started with your own assertions.</p>
 <h2 id="api-reference">API Reference</h2>
 </article>
-              <div id="type-section" class="segment">
-                <div class="summary"><h3 id="type-object-">type(object)</h3>
+              <div id="getPathValue-section" class="segment">
+                <div class="summary"><h3 id="-getpathvalue-path-object-">.getPathValue(path, object)</h3>
 </div>
                 <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">object</span><span class="desc">to detect type of</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">path</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
                 </ul>
-                <div class="description"><p>Better implementation of <code>typeof</code> detection that can
-be used cross-browser. Handles the inconsistencies of
-Array, <code>null</code>, and <code>undefined</code> detection.</p>
-<pre><code>utils.type({}) <span class="comment">// 'object'</span>
-utils.type(<span class="literal">null</span>) <span class="comment">// `null'</span>
-utils.type(undefined) <span class="comment">// `undefined`</span>
-utils.type([]) <span class="comment">// `array`</span></code></pre>
+                <div class="description"><p>This allows the retrieval of values in an
+object given a string path.</p>
+<pre><code><span class="keyword">var</span> obj = {
+    prop1: {
+        arr: [<span class="string">'a'</span>, <span class="string">'b'</span>, <span class="string">'c'</span>]
+      , str: <span class="string">'Hello'</span>
+    }
+  , prop2: {
+        arr: [ { nested: <span class="string">'Universe'</span> } ]
+      , str: <span class="string">'Hello again!'</span>
+    }
+}</code></pre>
+<p>The following would be the results.</p>
+<pre><code>getPathValue(<span class="string">'prop1.str'</span>, obj); <span class="comment">// Hello</span>
+getPathValue(<span class="string">'prop1.att[2]'</span>, obj); <span class="comment">// b</span>
+getPathValue(<span class="string">'prop2.arr[0].nested'</span>, obj); <span class="comment">// Universe</span></code></pre>
+</div>
+              </div>
+              <div id="assert-section" class="segment">
+                <div class="summary"><h3 id="-assert-expression-message-negatemessage-expected-actual-showdiff-">.assert(expression, message, negateMessage, expected, actual, showDiff)</h3>
+</div>
+                <ul class="tags">
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Philosophical &#125;</span><span class="name">expression</span><span class="desc">to be tested</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String | Function &#125;</span><span class="name">message</span><span class="desc">or function that returns message to display if expression fails</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String | Function &#125;</span><span class="name">negatedMessage</span><span class="desc">or function that returns negatedMessage to display if negated expression fails</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">expected</span><span class="desc">value (remember to check for negation)</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Mixed &#125;</span><span class="name">actual</span><span class="desc">(optional) will default to `this.obj`</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Boolean &#125;</span><span class="name">showDiff</span><span class="desc">(optional) when set to `true`, assert will display a diff in addition to the message if expression fails</span></li>
+                </ul>
+                <div class="description"><p>Executes an expression and check expectations. Throws AssertionError for reporting if test doesn&#39;t pass.</p>
 </div>
               </div>
               <div id="addMethod-section" class="segment">
@@ -152,30 +176,26 @@ to be used for name.</p>
 <pre><code>expect(myFoo).to.be.foo;</code></pre>
 </div>
               </div>
-              <div id="overwriteProperty-section" class="segment">
-                <div class="summary"><h3 id="overwriteproperty-ctx-name-fn-">overwriteProperty (ctx, name, fn)</h3>
+              <div id="addChainableMethod-section" class="segment">
+                <div class="summary"><h3 id="addchainablemethod-ctx-name-method-chainingbehavior-">addChainableMethod (ctx, name, method, chainingBehavior)</h3>
 </div>
                 <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">ctx</span><span class="desc">object whose property is to be overwritten</span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">name</span><span class="desc">of property to overwrite</span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">getter</span><span class="desc">function that returns a getter function to be used for name</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">ctx</span><span class="desc">object to which the method is added</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">name</span><span class="desc">of method to add</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">method</span><span class="desc">function to be used for `name`, when called</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">chainingBehavior</span><span class="desc">function to be called every time the property is accessed</span></li>
                 </ul>
-                <div class="description"><p>Overwites an already existing property getter and provides
-access to previous value. Must return function to use as getter.</p>
-<pre><code>utils.overwriteProperty(chai.Assertion.prototype, <span class="string">'ok'</span>, <span class="function"><span class="keyword">function</span> <span class="params">(_super)</span> {</span>
-  <span class="keyword">return</span> <span class="function"><span class="keyword">function</span> <span class="params">()</span> {</span>
-    <span class="keyword">var</span> obj = utils.flag(<span class="keyword">this</span>, <span class="string">'object'</span>);
-    <span class="keyword">if</span> (obj <span class="keyword">instanceof</span> Foo) {
-      <span class="keyword">new</span> chai.Assertion(obj.name).to.equal(<span class="string">'bar'</span>);
-    } <span class="keyword">else</span> {
-      _super.call(<span class="keyword">this</span>);
-    }
-  }
+                <div class="description"><p>Adds a method to an object, such that the method can also be chained.</p>
+<pre><code>utils.addChainableMethod(chai.Assertion.prototype, <span class="string">'foo'</span>, <span class="function"><span class="keyword">function</span> <span class="params">(str)</span> {</span>
+  <span class="keyword">var</span> obj = utils.flag(<span class="keyword">this</span>, <span class="string">'object'</span>);
+  <span class="keyword">new</span> chai.Assertion(obj).to.be.equal(str);
 });</code></pre>
 <p>Can also be accessed directly from <code>chai.Assertion</code>.</p>
-<pre><code>chai.Assertion.overwriteProperty(<span class="string">'foo'</span>, fn);</code></pre>
-<p>Then can be used as any other assertion.</p>
-<pre><code>expect(myFoo).to.be.ok;</code></pre>
+<pre><code>chai.Assertion.addChainableMethod(<span class="string">'foo'</span>, fn, chainingBehavior);</code></pre>
+<p>The result can then be used as both a method assertion, executing both <code>method</code> and
+<code>chainingBehavior</code>, or as a language chain, which only executes <code>chainingBehavior</code>.</p>
+<pre><code>expect(fooStr).to.be.foo(<span class="string">'bar'</span>);
+expect(fooStr).to.be.foo.equal(<span class="string">'foo'</span>);</code></pre>
 </div>
               </div>
               <div id="overwriteChainableMethod-section" class="segment">
@@ -239,51 +259,30 @@ utils.transferFlags(assertion, newAssertion);
 utils.transferFlags(assertion, anotherAssertion, <span class="literal">false</span>);</code></pre>
 </div>
               </div>
-              <div id="getPathValue-section" class="segment">
-                <div class="summary"><h3 id="-getpathvalue-path-object-">.getPathValue(path, object)</h3>
+              <div id="overwriteProperty-section" class="segment">
+                <div class="summary"><h3 id="overwriteproperty-ctx-name-fn-">overwriteProperty (ctx, name, fn)</h3>
 </div>
                 <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">path</span><span class="desc"></span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">object</span><span class="desc"></span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">ctx</span><span class="desc">object whose property is to be overwritten</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">name</span><span class="desc">of property to overwrite</span></li>
+                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">getter</span><span class="desc">function that returns a getter function to be used for name</span></li>
                 </ul>
-                <div class="description"><p>This allows the retrieval of values in an
-object given a string path.</p>
-<pre><code><span class="keyword">var</span> obj = {
-    prop1: {
-        arr: [<span class="string">'a'</span>, <span class="string">'b'</span>, <span class="string">'c'</span>]
-      , str: <span class="string">'Hello'</span>
+                <div class="description"><p>Overwites an already existing property getter and provides
+access to previous value. Must return function to use as getter.</p>
+<pre><code>utils.overwriteProperty(chai.Assertion.prototype, <span class="string">'ok'</span>, <span class="function"><span class="keyword">function</span> <span class="params">(_super)</span> {</span>
+  <span class="keyword">return</span> <span class="function"><span class="keyword">function</span> <span class="params">()</span> {</span>
+    <span class="keyword">var</span> obj = utils.flag(<span class="keyword">this</span>, <span class="string">'object'</span>);
+    <span class="keyword">if</span> (obj <span class="keyword">instanceof</span> Foo) {
+      <span class="keyword">new</span> chai.Assertion(obj.name).to.equal(<span class="string">'bar'</span>);
+    } <span class="keyword">else</span> {
+      _super.call(<span class="keyword">this</span>);
     }
-  , prop2: {
-        arr: [ { nested: <span class="string">'Universe'</span> } ]
-      , str: <span class="string">'Hello again!'</span>
-    }
-}</code></pre>
-<p>The following would be the results.</p>
-<pre><code>getPathValue(<span class="string">'prop1.str'</span>, obj); <span class="comment">// Hello</span>
-getPathValue(<span class="string">'prop1.att[2]'</span>, obj); <span class="comment">// b</span>
-getPathValue(<span class="string">'prop2.arr[0].nested'</span>, obj); <span class="comment">// Universe</span></code></pre>
-</div>
-              </div>
-              <div id="addChainableMethod-section" class="segment">
-                <div class="summary"><h3 id="addchainablemethod-ctx-name-method-chainingbehavior-">addChainableMethod (ctx, name, method, chainingBehavior)</h3>
-</div>
-                <ul class="tags">
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Object &#125;</span><span class="name">ctx</span><span class="desc">object to which the method is added</span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; String &#125;</span><span class="name">name</span><span class="desc">of method to add</span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">method</span><span class="desc">function to be used for `name`, when called</span></li>
-                  <li class="tag"><span class="type">&#64;param</span><span class="types">&#123; Function &#125;</span><span class="name">chainingBehavior</span><span class="desc">function to be called every time the property is accessed</span></li>
-                </ul>
-                <div class="description"><p>Adds a method to an object, such that the method can also be chained.</p>
-<pre><code>utils.addChainableMethod(chai.Assertion.prototype, <span class="string">'foo'</span>, <span class="function"><span class="keyword">function</span> <span class="params">(str)</span> {</span>
-  <span class="keyword">var</span> obj = utils.flag(<span class="keyword">this</span>, <span class="string">'object'</span>);
-  <span class="keyword">new</span> chai.Assertion(obj).to.be.equal(str);
+  }
 });</code></pre>
 <p>Can also be accessed directly from <code>chai.Assertion</code>.</p>
-<pre><code>chai.Assertion.addChainableMethod(<span class="string">'foo'</span>, fn, chainingBehavior);</code></pre>
-<p>The result can then be used as both a method assertion, executing both <code>method</code> and
-<code>chainingBehavior</code>, or as a language chain, which only executes <code>chainingBehavior</code>.</p>
-<pre><code>expect(fooStr).to.be.foo(<span class="string">'bar'</span>);
-expect(fooStr).to.be.foo.equal(<span class="string">'foo'</span>);</code></pre>
+<pre><code>chai.Assertion.overwriteProperty(<span class="string">'foo'</span>, fn);</code></pre>
+<p>Then can be used as any other assertion.</p>
+<pre><code>expect(myFoo).to.be.ok;</code></pre>
 </div>
               </div>
             </div>

--- a/out/api/test/index.html
+++ b/out/api/test/index.html
@@ -10,7 +10,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/tests/mocha.js"></script>
     <script>mocha.setup('tdd');</script>
     <script src="/chai.js"></script>
@@ -40,8 +40,8 @@
       };
       
     </script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/chai.js
+++ b/out/chai.js
@@ -1,670 +1,7 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.chai = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = require('./lib/chai');
 
-;(function(){
-
-/**
- * Require the module at `name`.
- *
- * @param {String} name
- * @return {Object} exports
- * @api public
- */
-
-function require(name) {
-  var module = require.modules[name];
-  if (!module) throw new Error('failed to require "' + name + '"');
-
-  if (!('exports' in module) && typeof module.definition === 'function') {
-    module.client = module.component = true;
-    module.definition.call(this, module.exports = {}, module);
-    delete module.definition;
-  }
-
-  return module.exports;
-}
-
-/**
- * Meta info, accessible in the global scope unless you use AMD option.
- */
-
-require.loader = 'component';
-
-/**
- * Internal helper object, contains a sorting function for semantiv versioning
- */
-require.helper = {};
-require.helper.semVerSort = function(a, b) {
-  var aArray = a.version.split('.');
-  var bArray = b.version.split('.');
-  for (var i=0; i<aArray.length; ++i) {
-    var aInt = parseInt(aArray[i], 10);
-    var bInt = parseInt(bArray[i], 10);
-    if (aInt === bInt) {
-      var aLex = aArray[i].substr((""+aInt).length);
-      var bLex = bArray[i].substr((""+bInt).length);
-      if (aLex === '' && bLex !== '') return 1;
-      if (aLex !== '' && bLex === '') return -1;
-      if (aLex !== '' && bLex !== '') return aLex > bLex ? 1 : -1;
-      continue;
-    } else if (aInt > bInt) {
-      return 1;
-    } else {
-      return -1;
-    }
-  }
-  return 0;
-}
-
-/**
- * Find and require a module which name starts with the provided name.
- * If multiple modules exists, the highest semver is used. 
- * This function can only be used for remote dependencies.
-
- * @param {String} name - module name: `user~repo`
- * @param {Boolean} returnPath - returns the canonical require path if true, 
- *                               otherwise it returns the epxorted module
- */
-require.latest = function (name, returnPath) {
-  function showError(name) {
-    throw new Error('failed to find latest module of "' + name + '"');
-  }
-  // only remotes with semvers, ignore local files conataining a '/'
-  var versionRegexp = /(.*)~(.*)@v?(\d+\.\d+\.\d+[^\/]*)$/;
-  var remoteRegexp = /(.*)~(.*)/;
-  if (!remoteRegexp.test(name)) showError(name);
-  var moduleNames = Object.keys(require.modules);
-  var semVerCandidates = [];
-  var otherCandidates = []; // for instance: name of the git branch
-  for (var i=0; i<moduleNames.length; i++) {
-    var moduleName = moduleNames[i];
-    if (new RegExp(name + '@').test(moduleName)) {
-        var version = moduleName.substr(name.length+1);
-        var semVerMatch = versionRegexp.exec(moduleName);
-        if (semVerMatch != null) {
-          semVerCandidates.push({version: version, name: moduleName});
-        } else {
-          otherCandidates.push({version: version, name: moduleName});
-        } 
-    }
-  }
-  if (semVerCandidates.concat(otherCandidates).length === 0) {
-    showError(name);
-  }
-  if (semVerCandidates.length > 0) {
-    var module = semVerCandidates.sort(require.helper.semVerSort).pop().name;
-    if (returnPath === true) {
-      return module;
-    }
-    return require(module);
-  }
-  // if the build contains more than one branch of the same module
-  // you should not use this funciton
-  var module = otherCandidates.sort(function(a, b) {return a.name > b.name})[0].name;
-  if (returnPath === true) {
-    return module;
-  }
-  return require(module);
-}
-
-/**
- * Registered modules.
- */
-
-require.modules = {};
-
-/**
- * Register module at `name` with callback `definition`.
- *
- * @param {String} name
- * @param {Function} definition
- * @api private
- */
-
-require.register = function (name, definition) {
-  require.modules[name] = {
-    definition: definition
-  };
-};
-
-/**
- * Define a module's exports immediately with `exports`.
- *
- * @param {String} name
- * @param {Generic} exports
- * @api private
- */
-
-require.define = function (name, exports) {
-  require.modules[name] = {
-    exports: exports
-  };
-};
-require.register("chaijs~assertion-error@1.0.0", function (exports, module) {
-/*!
- * assertion-error
- * Copyright(c) 2013 Jake Luer <jake@qualiancy.com>
- * MIT Licensed
- */
-
-/*!
- * Return a function that will copy properties from
- * one object to another excluding any originally
- * listed. Returned function will create a new `{}`.
- *
- * @param {String} excluded properties ...
- * @return {Function}
- */
-
-function exclude () {
-  var excludes = [].slice.call(arguments);
-
-  function excludeProps (res, obj) {
-    Object.keys(obj).forEach(function (key) {
-      if (!~excludes.indexOf(key)) res[key] = obj[key];
-    });
-  }
-
-  return function extendExclude () {
-    var args = [].slice.call(arguments)
-      , i = 0
-      , res = {};
-
-    for (; i < args.length; i++) {
-      excludeProps(res, args[i]);
-    }
-
-    return res;
-  };
-};
-
-/*!
- * Primary Exports
- */
-
-module.exports = AssertionError;
-
-/**
- * ### AssertionError
- *
- * An extension of the JavaScript `Error` constructor for
- * assertion and validation scenarios.
- *
- * @param {String} message
- * @param {Object} properties to include (optional)
- * @param {callee} start stack function (optional)
- */
-
-function AssertionError (message, _props, ssf) {
-  var extend = exclude('name', 'message', 'stack', 'constructor', 'toJSON')
-    , props = extend(_props || {});
-
-  // default values
-  this.message = message || 'Unspecified AssertionError';
-  this.showDiff = false;
-
-  // copy from properties
-  for (var key in props) {
-    this[key] = props[key];
-  }
-
-  // capture stack trace
-  ssf = ssf || arguments.callee;
-  if (ssf && Error.captureStackTrace) {
-    Error.captureStackTrace(this, ssf);
-  }
-}
-
-/*!
- * Inherit from Error.prototype
- */
-
-AssertionError.prototype = Object.create(Error.prototype);
-
-/*!
- * Statically set name
- */
-
-AssertionError.prototype.name = 'AssertionError';
-
-/*!
- * Ensure correct constructor
- */
-
-AssertionError.prototype.constructor = AssertionError;
-
-/**
- * Allow errors to be converted to JSON for static transfer.
- *
- * @param {Boolean} include stack (default: `true`)
- * @return {Object} object that can be `JSON.stringify`
- */
-
-AssertionError.prototype.toJSON = function (stack) {
-  var extend = exclude('constructor', 'toJSON', 'stack')
-    , props = extend({ name: this.name }, this);
-
-  // include stack if exists and not turned off
-  if (false !== stack && this.stack) {
-    props.stack = this.stack;
-  }
-
-  return props;
-};
-
-});
-
-require.register("chaijs~type-detect@0.1.1", function (exports, module) {
-/*!
- * type-detect
- * Copyright(c) 2013 jake luer <jake@alogicalparadox.com>
- * MIT Licensed
- */
-
-/*!
- * Primary Exports
- */
-
-var exports = module.exports = getType;
-
-/*!
- * Detectable javascript natives
- */
-
-var natives = {
-    '[object Array]': 'array'
-  , '[object RegExp]': 'regexp'
-  , '[object Function]': 'function'
-  , '[object Arguments]': 'arguments'
-  , '[object Date]': 'date'
-};
-
-/**
- * ### typeOf (obj)
- *
- * Use several different techniques to determine
- * the type of object being tested.
- *
- *
- * @param {Mixed} object
- * @return {String} object type
- * @api public
- */
-
-function getType (obj) {
-  var str = Object.prototype.toString.call(obj);
-  if (natives[str]) return natives[str];
-  if (obj === null) return 'null';
-  if (obj === undefined) return 'undefined';
-  if (obj === Object(obj)) return 'object';
-  return typeof obj;
-}
-
-exports.Library = Library;
-
-/**
- * ### Library
- *
- * Create a repository for custom type detection.
- *
- * ```js
- * var lib = new type.Library;
- * ```
- *
- */
-
-function Library () {
-  this.tests = {};
-}
-
-/**
- * #### .of (obj)
- *
- * Expose replacement `typeof` detection to the library.
- *
- * ```js
- * if ('string' === lib.of('hello world')) {
- *   // ...
- * }
- * ```
- *
- * @param {Mixed} object to test
- * @return {String} type
- */
-
-Library.prototype.of = getType;
-
-/**
- * #### .define (type, test)
- *
- * Add a test to for the `.test()` assertion.
- *
- * Can be defined as a regular expression:
- *
- * ```js
- * lib.define('int', /^[0-9]+$/);
- * ```
- *
- * ... or as a function:
- *
- * ```js
- * lib.define('bln', function (obj) {
- *   if ('boolean' === lib.of(obj)) return true;
- *   var blns = [ 'yes', 'no', 'true', 'false', 1, 0 ];
- *   if ('string' === lib.of(obj)) obj = obj.toLowerCase();
- *   return !! ~blns.indexOf(obj);
- * });
- * ```
- *
- * @param {String} type
- * @param {RegExp|Function} test
- * @api public
- */
-
-Library.prototype.define = function (type, test) {
-  if (arguments.length === 1) return this.tests[type];
-  this.tests[type] = test;
-  return this;
-};
-
-/**
- * #### .test (obj, test)
- *
- * Assert that an object is of type. Will first
- * check natives, and if that does not pass it will
- * use the user defined custom tests.
- *
- * ```js
- * assert(lib.test('1', 'int'));
- * assert(lib.test('yes', 'bln'));
- * ```
- *
- * @param {Mixed} object
- * @param {String} type
- * @return {Boolean} result
- * @api public
- */
-
-Library.prototype.test = function (obj, type) {
-  if (type === getType(obj)) return true;
-  var test = this.tests[type];
-
-  if (test && 'regexp' === getType(test)) {
-    return test.test(obj);
-  } else if (test && 'function' === getType(test)) {
-    return test(obj);
-  } else {
-    throw new ReferenceError('Type test "' + type + '" not defined or invalid.');
-  }
-};
-
-});
-
-require.register("chaijs~deep-eql@0.1.3", function (exports, module) {
-/*!
- * deep-eql
- * Copyright(c) 2013 Jake Luer <jake@alogicalparadox.com>
- * MIT Licensed
- */
-
-/*!
- * Module dependencies
- */
-
-var type = require('chaijs~type-detect@0.1.1');
-
-/*!
- * Buffer.isBuffer browser shim
- */
-
-var Buffer;
-try { Buffer = require('buffer').Buffer; }
-catch(ex) {
-  Buffer = {};
-  Buffer.isBuffer = function() { return false; }
-}
-
-/*!
- * Primary Export
- */
-
-module.exports = deepEqual;
-
-/**
- * Assert super-strict (egal) equality between
- * two objects of any type.
- *
- * @param {Mixed} a
- * @param {Mixed} b
- * @param {Array} memoised (optional)
- * @return {Boolean} equal match
- */
-
-function deepEqual(a, b, m) {
-  if (sameValue(a, b)) {
-    return true;
-  } else if ('date' === type(a)) {
-    return dateEqual(a, b);
-  } else if ('regexp' === type(a)) {
-    return regexpEqual(a, b);
-  } else if (Buffer.isBuffer(a)) {
-    return bufferEqual(a, b);
-  } else if ('arguments' === type(a)) {
-    return argumentsEqual(a, b, m);
-  } else if (!typeEqual(a, b)) {
-    return false;
-  } else if (('object' !== type(a) && 'object' !== type(b))
-  && ('array' !== type(a) && 'array' !== type(b))) {
-    return sameValue(a, b);
-  } else {
-    return objectEqual(a, b, m);
-  }
-}
-
-/*!
- * Strict (egal) equality test. Ensures that NaN always
- * equals NaN and `-0` does not equal `+0`.
- *
- * @param {Mixed} a
- * @param {Mixed} b
- * @return {Boolean} equal match
- */
-
-function sameValue(a, b) {
-  if (a === b) return a !== 0 || 1 / a === 1 / b;
-  return a !== a && b !== b;
-}
-
-/*!
- * Compare the types of two given objects and
- * return if they are equal. Note that an Array
- * has a type of `array` (not `object`) and arguments
- * have a type of `arguments` (not `array`/`object`).
- *
- * @param {Mixed} a
- * @param {Mixed} b
- * @return {Boolean} result
- */
-
-function typeEqual(a, b) {
-  return type(a) === type(b);
-}
-
-/*!
- * Compare two Date objects by asserting that
- * the time values are equal using `saveValue`.
- *
- * @param {Date} a
- * @param {Date} b
- * @return {Boolean} result
- */
-
-function dateEqual(a, b) {
-  if ('date' !== type(b)) return false;
-  return sameValue(a.getTime(), b.getTime());
-}
-
-/*!
- * Compare two regular expressions by converting them
- * to string and checking for `sameValue`.
- *
- * @param {RegExp} a
- * @param {RegExp} b
- * @return {Boolean} result
- */
-
-function regexpEqual(a, b) {
-  if ('regexp' !== type(b)) return false;
-  return sameValue(a.toString(), b.toString());
-}
-
-/*!
- * Assert deep equality of two `arguments` objects.
- * Unfortunately, these must be sliced to arrays
- * prior to test to ensure no bad behavior.
- *
- * @param {Arguments} a
- * @param {Arguments} b
- * @param {Array} memoize (optional)
- * @return {Boolean} result
- */
-
-function argumentsEqual(a, b, m) {
-  if ('arguments' !== type(b)) return false;
-  a = [].slice.call(a);
-  b = [].slice.call(b);
-  return deepEqual(a, b, m);
-}
-
-/*!
- * Get enumerable properties of a given object.
- *
- * @param {Object} a
- * @return {Array} property names
- */
-
-function enumerable(a) {
-  var res = [];
-  for (var key in a) res.push(key);
-  return res;
-}
-
-/*!
- * Simple equality for flat iterable objects
- * such as Arrays or Node.js buffers.
- *
- * @param {Iterable} a
- * @param {Iterable} b
- * @return {Boolean} result
- */
-
-function iterableEqual(a, b) {
-  if (a.length !==  b.length) return false;
-
-  var i = 0;
-  var match = true;
-
-  for (; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      match = false;
-      break;
-    }
-  }
-
-  return match;
-}
-
-/*!
- * Extension to `iterableEqual` specifically
- * for Node.js Buffers.
- *
- * @param {Buffer} a
- * @param {Mixed} b
- * @return {Boolean} result
- */
-
-function bufferEqual(a, b) {
-  if (!Buffer.isBuffer(b)) return false;
-  return iterableEqual(a, b);
-}
-
-/*!
- * Block for `objectEqual` ensuring non-existing
- * values don't get in.
- *
- * @param {Mixed} object
- * @return {Boolean} result
- */
-
-function isValue(a) {
-  return a !== null && a !== undefined;
-}
-
-/*!
- * Recursively check the equality of two objects.
- * Once basic sameness has been established it will
- * defer to `deepEqual` for each enumerable key
- * in the object.
- *
- * @param {Mixed} a
- * @param {Mixed} b
- * @return {Boolean} result
- */
-
-function objectEqual(a, b, m) {
-  if (!isValue(a) || !isValue(b)) {
-    return false;
-  }
-
-  if (a.prototype !== b.prototype) {
-    return false;
-  }
-
-  var i;
-  if (m) {
-    for (i = 0; i < m.length; i++) {
-      if ((m[i][0] === a && m[i][1] === b)
-      ||  (m[i][0] === b && m[i][1] === a)) {
-        return true;
-      }
-    }
-  } else {
-    m = [];
-  }
-
-  try {
-    var ka = enumerable(a);
-    var kb = enumerable(b);
-  } catch (ex) {
-    return false;
-  }
-
-  ka.sort();
-  kb.sort();
-
-  if (!iterableEqual(ka, kb)) {
-    return false;
-  }
-
-  m.push([ a, b ]);
-
-  var key;
-  for (i = ka.length - 1; i >= 0; i--) {
-    key = ka[i];
-    if (!deepEqual(a[key], b[key], m)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-});
-
-require.register("chai", function (exports, module) {
-module.exports = require('chai/lib/chai.js');
-
-});
-
-require.register("chai/lib/chai.js", function (exports, module) {
+},{"./lib/chai":2}],2:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011-2014 Jake Luer <jake@alogicalparadox.com>
@@ -678,19 +15,19 @@ var used = []
  * Chai version
  */
 
-exports.version = '2.1.0';
+exports.version = '3.4.2';
 
 /*!
  * Assertion Error
  */
 
-exports.AssertionError = require('chaijs~assertion-error@1.0.0');
+exports.AssertionError = require('assertion-error');
 
 /*!
  * Utils for plugins (not exported)
  */
 
-var util = require('chai/lib/chai/utils/index.js');
+var util = require('./chai/utils');
 
 /**
  * # .use(function)
@@ -721,47 +58,45 @@ exports.util = util;
  * Configuration
  */
 
-var config = require('chai/lib/chai/config.js');
+var config = require('./chai/config');
 exports.config = config;
 
 /*!
  * Primary `Assertion` prototype
  */
 
-var assertion = require('chai/lib/chai/assertion.js');
+var assertion = require('./chai/assertion');
 exports.use(assertion);
 
 /*!
  * Core Assertions
  */
 
-var core = require('chai/lib/chai/core/assertions.js');
+var core = require('./chai/core/assertions');
 exports.use(core);
 
 /*!
  * Expect interface
  */
 
-var expect = require('chai/lib/chai/interface/expect.js');
+var expect = require('./chai/interface/expect');
 exports.use(expect);
 
 /*!
  * Should interface
  */
 
-var should = require('chai/lib/chai/interface/should.js');
+var should = require('./chai/interface/should');
 exports.use(should);
 
 /*!
  * Assert interface
  */
 
-var assert = require('chai/lib/chai/interface/assert.js');
+var assert = require('./chai/interface/assert');
 exports.use(assert);
 
-});
-
-require.register("chai/lib/chai/assertion.js", function (exports, module) {
+},{"./chai/assertion":3,"./chai/config":4,"./chai/core/assertions":5,"./chai/interface/assert":6,"./chai/interface/expect":7,"./chai/interface/should":8,"./chai/utils":22,"assertion-error":30}],3:[function(require,module,exports){
 /*!
  * chai
  * http://chaijs.com
@@ -769,7 +104,7 @@ require.register("chai/lib/chai/assertion.js", function (exports, module) {
  * MIT Licensed
  */
 
-var config = require('chai/lib/chai/config.js');
+var config = require('./config');
 
 module.exports = function (_chai, util) {
   /*!
@@ -845,17 +180,18 @@ module.exports = function (_chai, util) {
     util.overwriteChainableMethod(this.prototype, name, fn, chainingBehavior);
   };
 
-  /*!
-   * ### .assert(expression, message, negateMessage, expected, actual)
+  /**
+   * ### .assert(expression, message, negateMessage, expected, actual, showDiff)
    *
    * Executes an expression and check expectations. Throws AssertionError for reporting if test doesn't pass.
    *
    * @name assert
    * @param {Philosophical} expression to be tested
-   * @param {String or Function} message or function that returns message to display if fails
-   * @param {String or Function} negatedMessage or function that returns negatedMessage to display if negated expression fails
+   * @param {String|Function} message or function that returns message to display if expression fails
+   * @param {String|Function} negatedMessage or function that returns negatedMessage to display if negated expression fails
    * @param {Mixed} expected value (remember to check for negation)
    * @param {Mixed} actual (optional) will default to `this.obj`
+   * @param {Boolean} showDiff (optional) when set to `true`, assert will display a diff in addition to the message if expression fails
    * @api private
    */
 
@@ -893,9 +229,7 @@ module.exports = function (_chai, util) {
   });
 };
 
-});
-
-require.register("chai/lib/chai/config.js", function (exports, module) {
+},{"./config":4}],4:[function(require,module,exports){
 module.exports = {
 
   /**
@@ -932,10 +266,15 @@ module.exports = {
    * ### config.truncateThreshold
    *
    * User configurable property, sets length threshold for actual and
-   * expected values in assertion errors. If this threshold is exceeded,
-   * the value is truncated.
+   * expected values in assertion errors. If this threshold is exceeded, for
+   * example for large data structures, the value is replaced with something
+   * like `[ Array(3) ]` or `{ Object (prop1, prop2) }`.
    *
    * Set it to zero if you want to disable truncating altogether.
+   *
+   * This is especially userful when doing assertions on arrays: having this
+   * set to a reasonable large value makes the failure messages readily
+   * inspectable.
    *
    *     chai.config.truncateThreshold = 0;  // disable truncating
    *
@@ -947,9 +286,7 @@ module.exports = {
 
 };
 
-});
-
-require.register("chai/lib/chai/core/assertions.js", function (exports, module) {
+},{}],5:[function(require,module,exports){
 /*!
  * chai
  * http://chaijs.com
@@ -987,6 +324,7 @@ module.exports = function (chai, _) {
    * - same
    *
    * @name language chains
+   * @namespace BDD
    * @api public
    */
 
@@ -1010,6 +348,7 @@ module.exports = function (chai, _) {
    *       .and.not.equal('bar');
    *
    * @name not
+   * @namespace BDD
    * @api public
    */
 
@@ -1027,7 +366,14 @@ module.exports = function (chai, _) {
    *     expect({ foo: { bar: { baz: 'quux' } } })
    *       .to.have.deep.property('foo.bar.baz', 'quux');
    *
+   * `.deep.property` special characters can be escaped
+   * by adding two slashes before the `.` or `[]`.
+   *
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+   *
    * @name deep
+   * @namespace BDD
    * @api public
    */
 
@@ -1039,11 +385,12 @@ module.exports = function (chai, _) {
    * ### .any
    *
    * Sets the `any` flag, (opposite of the `all` flag)
-   * later used in the `keys` assertion. 
+   * later used in the `keys` assertion.
    *
    *     expect(foo).to.have.any.keys('bar', 'baz');
    *
    * @name any
+   * @namespace BDD
    * @api public
    */
 
@@ -1056,12 +403,13 @@ module.exports = function (chai, _) {
   /**
    * ### .all
    *
-   * Sets the `all` flag (opposite of the `any` flag) 
+   * Sets the `all` flag (opposite of the `any` flag)
    * later used by the `keys` assertion.
    *
    *     expect(foo).to.have.all.keys('bar', 'baz');
    *
    * @name all
+   * @namespace BDD
    * @api public
    */
 
@@ -1082,6 +430,13 @@ module.exports = function (chai, _) {
    *     expect({ foo: 'bar' }).to.be.an('object');
    *     expect(null).to.be.a('null');
    *     expect(undefined).to.be.an('undefined');
+   *     expect(new Error).to.be.an('error');
+   *     expect(new Promise).to.be.a('promise');
+   *     expect(new Float32Array()).to.be.a('float32array');
+   *     expect(Symbol()).to.be.a('symbol');
+   *
+   *     // es6 overrides
+   *     expect({[Symbol.toStringTag]:()=>'foo'}).to.be.a('foo');
    *
    *     // language chain
    *     expect(foo).to.be.an.instanceof(Foo);
@@ -1090,6 +445,7 @@ module.exports = function (chai, _) {
    * @alias an
    * @param {String} type
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1127,6 +483,7 @@ module.exports = function (chai, _) {
    * @alias contains
    * @param {Object|String|Number} obj
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1135,9 +492,12 @@ module.exports = function (chai, _) {
   }
 
   function include (val, msg) {
+    _.expectTypes(this, ['array', 'object', 'string']);
+
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     var expected = false;
+
     if (_.type(obj) === 'array' && _.type(val) === 'object') {
       for (var i in obj) {
         if (_.eql(obj[i], val)) {
@@ -1154,7 +514,7 @@ module.exports = function (chai, _) {
       for (var k in val) subset[k] = obj[k];
       expected = _.eql(subset, val);
     } else {
-      expected = obj && ~obj.indexOf(val);
+      expected = (obj != undefined) && ~obj.indexOf(val);
     }
     this.assert(
         expected
@@ -1172,13 +532,14 @@ module.exports = function (chai, _) {
    *
    * Asserts that the target is truthy.
    *
-   *     expect('everthing').to.be.ok;
+   *     expect('everything').to.be.ok;
    *     expect(1).to.be.ok;
    *     expect(false).to.not.be.ok;
    *     expect(undefined).to.not.be.ok;
    *     expect(null).to.not.be.ok;
    *
    * @name ok
+   * @namespace BDD
    * @api public
    */
 
@@ -1198,6 +559,7 @@ module.exports = function (chai, _) {
    *     expect(1).to.not.be.true;
    *
    * @name true
+   * @namespace BDD
    * @api public
    */
 
@@ -1219,6 +581,7 @@ module.exports = function (chai, _) {
    *     expect(0).to.not.be.false;
    *
    * @name false
+   * @namespace BDD
    * @api public
    */
 
@@ -1237,9 +600,10 @@ module.exports = function (chai, _) {
    * Asserts that the target is `null`.
    *
    *     expect(null).to.be.null;
-   *     expect(undefined).not.to.be.null;
+   *     expect(undefined).to.not.be.null;
    *
    * @name null
+   * @namespace BDD
    * @api public
    */
 
@@ -1260,6 +624,7 @@ module.exports = function (chai, _) {
    *     expect(null).to.not.be.undefined;
    *
    * @name undefined
+   * @namespace BDD
    * @api public
    */
 
@@ -1268,6 +633,26 @@ module.exports = function (chai, _) {
         undefined === flag(this, 'object')
       , 'expected #{this} to be undefined'
       , 'expected #{this} not to be undefined'
+    );
+  });
+
+  /**
+   * ### .NaN
+   * Asserts that the target is `NaN`.
+   *
+   *     expect('foo').to.be.NaN;
+   *     expect(4).not.to.be.NaN;
+   *
+   * @name NaN
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addProperty('NaN', function () {
+    this.assert(
+        isNaN(flag(this, 'object'))
+        , 'expected #{this} to be NaN'
+        , 'expected #{this} not to be NaN'
     );
   });
 
@@ -1285,6 +670,7 @@ module.exports = function (chai, _) {
    *     expect(baz).to.not.exist;
    *
    * @name exist
+   * @namespace BDD
    * @api public
    */
 
@@ -1300,7 +686,7 @@ module.exports = function (chai, _) {
   /**
    * ### .empty
    *
-   * Asserts that the target's length is `0`. For arrays, it checks
+   * Asserts that the target's length is `0`. For arrays and strings, it checks
    * the `length` property. For objects, it gets the count of
    * enumerable keys.
    *
@@ -1309,6 +695,7 @@ module.exports = function (chai, _) {
    *     expect({}).to.be.empty;
    *
    * @name empty
+   * @namespace BDD
    * @api public
    */
 
@@ -1340,6 +727,7 @@ module.exports = function (chai, _) {
    *
    * @name arguments
    * @alias Arguments
+   * @namespace BDD
    * @api public
    */
 
@@ -1375,6 +763,7 @@ module.exports = function (chai, _) {
    * @alias deep.equal
    * @param {Mixed} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1411,6 +800,7 @@ module.exports = function (chai, _) {
    * @alias eqls
    * @param {Mixed} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1449,6 +839,7 @@ module.exports = function (chai, _) {
    * @alias greaterThan
    * @param {Number} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1497,6 +888,7 @@ module.exports = function (chai, _) {
    * @alias gte
    * @param {Number} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1545,6 +937,7 @@ module.exports = function (chai, _) {
    * @alias lessThan
    * @param {Number} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1593,6 +986,7 @@ module.exports = function (chai, _) {
    * @alias lte
    * @param {Number} value
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1640,6 +1034,7 @@ module.exports = function (chai, _) {
    * @param {Number} start lowerbound inclusive
    * @param {Number} finish upperbound inclusive
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1679,6 +1074,7 @@ module.exports = function (chai, _) {
    * @param {Constructor} constructor
    * @param {String} message _optional_
    * @alias instanceOf
+   * @namespace BDD
    * @api public
    */
 
@@ -1713,7 +1109,7 @@ module.exports = function (chai, _) {
    *         green: { tea: 'matcha' }
    *       , teas: [ 'chai', 'matcha', { tea: 'konacha' } ]
    *     };
-
+   *
    *     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
    *     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');
@@ -1745,12 +1141,25 @@ module.exports = function (chai, _) {
    *       .with.deep.property('[2]')
    *         .that.deep.equals({ tea: 'konacha' });
    *
+   * Note that dots and bracket in `name` must be backslash-escaped when
+   * the `deep` flag is set, while they must NOT be escaped when the `deep`
+   * flag is not set.
+   *
+   *     // simple referencing
+   *     var css = { '.link[target]': 42 };
+   *     expect(css).to.have.property('.link[target]', 42);
+   *
+   *     // deep referencing
+   *     var deepCss = { '.link': { '[target]': 42 }};
+   *     expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+   *
    * @name property
    * @alias deep.property
    * @param {String} name
    * @param {Mixed} value (optional)
    * @param {String} message _optional_
    * @returns value of property for chaining
+   * @namespace BDD
    * @api public
    */
 
@@ -1769,7 +1178,7 @@ module.exports = function (chai, _) {
         ? pathInfo.value
         : obj[name];
 
-    if (negate && undefined !== val) {
+    if (negate && arguments.length > 1) {
       if (undefined === value) {
         msg = (msg != null) ? msg + ': ' : '';
         throw new Error(msg + _.inspect(obj) + ' has no ' + descriptor + _.inspect(name));
@@ -1781,7 +1190,7 @@ module.exports = function (chai, _) {
         , 'expected #{this} to not have ' + descriptor + _.inspect(name));
     }
 
-    if (undefined !== val) {
+    if (arguments.length > 1) {
       this.assert(
           val === value
         , 'expected #{this} to have a ' + descriptor + _.inspect(name) + ' of #{exp}, but got #{act}'
@@ -1806,6 +1215,7 @@ module.exports = function (chai, _) {
    * @alias haveOwnProperty
    * @param {String} name
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1823,16 +1233,60 @@ module.exports = function (chai, _) {
   Assertion.addMethod('haveOwnProperty', assertOwnProperty);
 
   /**
-   * ### .length(value)
+   * ### .ownPropertyDescriptor(name[, descriptor[, message]])
    *
-   * Asserts that the target's `length` property has
-   * the expected value.
+   * Asserts that the target has an own property descriptor `name`, that optionally matches `descriptor`.
    *
-   *     expect([ 1, 2, 3]).to.have.length(3);
-   *     expect('foobar').to.have.length(6);
+   *     expect('test').to.have.ownPropertyDescriptor('length');
+   *     expect('test').to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 4 });
+   *     expect('test').not.to.have.ownPropertyDescriptor('length', { enumerable: false, configurable: false, writable: false, value: 3 });
+   *     expect('test').ownPropertyDescriptor('length').to.have.property('enumerable', false);
+   *     expect('test').ownPropertyDescriptor('length').to.have.keys('value');
    *
-   * Can also be used as a chain precursor to a value
-   * comparison for the length property.
+   * @name ownPropertyDescriptor
+   * @alias haveOwnPropertyDescriptor
+   * @param {String} name
+   * @param {Object} descriptor _optional_
+   * @param {String} message _optional_
+   * @namespace BDD
+   * @api public
+   */
+
+  function assertOwnPropertyDescriptor (name, descriptor, msg) {
+    if (typeof descriptor === 'string') {
+      msg = descriptor;
+      descriptor = null;
+    }
+    if (msg) flag(this, 'message', msg);
+    var obj = flag(this, 'object');
+    var actualDescriptor = Object.getOwnPropertyDescriptor(Object(obj), name);
+    if (actualDescriptor && descriptor) {
+      this.assert(
+          _.eql(descriptor, actualDescriptor)
+        , 'expected the own property descriptor for ' + _.inspect(name) + ' on #{this} to match ' + _.inspect(descriptor) + ', got ' + _.inspect(actualDescriptor)
+        , 'expected the own property descriptor for ' + _.inspect(name) + ' on #{this} to not match ' + _.inspect(descriptor)
+        , descriptor
+        , actualDescriptor
+        , true
+      );
+    } else {
+      this.assert(
+          actualDescriptor
+        , 'expected #{this} to have an own property descriptor for ' + _.inspect(name)
+        , 'expected #{this} to not have an own property descriptor for ' + _.inspect(name)
+      );
+    }
+    flag(this, 'object', actualDescriptor);
+  }
+
+  Assertion.addMethod('ownPropertyDescriptor', assertOwnPropertyDescriptor);
+  Assertion.addMethod('haveOwnPropertyDescriptor', assertOwnPropertyDescriptor);
+
+  /**
+   * ### .length
+   *
+   * Sets the `doLength` flag later used as a chain precursor to a value
+   * comparison for the `length` property.
    *
    *     expect('foo').to.have.length.above(2);
    *     expect([ 1, 2, 3 ]).to.have.length.above(2);
@@ -1841,10 +1295,29 @@ module.exports = function (chai, _) {
    *     expect('foo').to.have.length.within(2,4);
    *     expect([ 1, 2, 3 ]).to.have.length.within(2,4);
    *
+   * *Deprecation notice:* Using `length` as an assertion will be deprecated
+   * in version 2.4.0 and removed in 3.0.0. Code using the old style of
+   * asserting for `length` property value using `length(value)` should be
+   * switched to use `lengthOf(value)` instead.
+   *
    * @name length
-   * @alias lengthOf
+   * @namespace BDD
+   * @api public
+   */
+
+  /**
+   * ### .lengthOf(value[, message])
+   *
+   * Asserts that the target's `length` property has
+   * the expected value.
+   *
+   *     expect([ 1, 2, 3]).to.have.lengthOf(3);
+   *     expect('foobar').to.have.lengthOf(6);
+   *
+   * @name lengthOf
    * @param {Number} length
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1878,12 +1351,13 @@ module.exports = function (chai, _) {
    *     expect('foobar').to.match(/^foo/);
    *
    * @name match
+   * @alias matches
    * @param {RegExp} RegularExpression
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
-
-  Assertion.addMethod('match', function (re, msg) {
+  function assertMatch(re, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     this.assert(
@@ -1891,7 +1365,10 @@ module.exports = function (chai, _) {
       , 'expected #{this} to match ' + re
       , 'expected #{this} not to match ' + re
     );
-  });
+  }
+
+  Assertion.addMethod('match', assertMatch);
+  Assertion.addMethod('matches', assertMatch);
 
   /**
    * ### .string(string)
@@ -1903,6 +1380,7 @@ module.exports = function (chai, _) {
    * @name string
    * @param {String} string
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -1923,37 +1401,38 @@ module.exports = function (chai, _) {
    * ### .keys(key1, [key2], [...])
    *
    * Asserts that the target contains any or all of the passed-in keys.
-   * Use in combination with `any`, `all`, `contains`, or `have` will affect 
+   * Use in combination with `any`, `all`, `contains`, or `have` will affect
    * what will pass.
-   * 
-   * When used in conjunction with `any`, at least one key that is passed 
-   * in must exist in the target object. This is regardless whether or not 
+   *
+   * When used in conjunction with `any`, at least one key that is passed
+   * in must exist in the target object. This is regardless whether or not
    * the `have` or `contain` qualifiers are used. Note, either `any` or `all`
    * should be used in the assertion. If neither are used, the assertion is
    * defaulted to `all`.
-   * 
-   * When both `all` and `contain` are used, the target object must have at 
+   *
+   * When both `all` and `contain` are used, the target object must have at
    * least all of the passed-in keys but may have more keys not listed.
-   * 
+   *
    * When both `all` and `have` are used, the target object must both contain
    * all of the passed-in keys AND the number of keys in the target object must
-   * match the number of keys passed in (in other words, a target object must 
+   * match the number of keys passed in (in other words, a target object must
    * have all and only all of the passed-in keys).
-   * 
+   *
    *     expect({ foo: 1, bar: 2 }).to.have.any.keys('foo', 'baz');
    *     expect({ foo: 1, bar: 2 }).to.have.any.keys('foo');
    *     expect({ foo: 1, bar: 2 }).to.contain.any.keys('bar', 'baz');
    *     expect({ foo: 1, bar: 2 }).to.contain.any.keys(['foo']);
    *     expect({ foo: 1, bar: 2 }).to.contain.any.keys({'foo': 6});
    *     expect({ foo: 1, bar: 2 }).to.have.all.keys(['bar', 'foo']);
-   *     expect({ foo: 1, bar: 2 }).to.have.all.keys({'bar': 6, 'foo', 7});
+   *     expect({ foo: 1, bar: 2 }).to.have.all.keys({'bar': 6, 'foo': 7});
    *     expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys(['bar', 'foo']);
-   *     expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys([{'bar': 6}}]);
+   *     expect({ foo: 1, bar: 2, baz: 3 }).to.contain.all.keys({'bar': 6});
    *
    *
    * @name keys
    * @alias key
-   * @param {String...|Array|Object} keys
+   * @param {...String|Array|Object} keys
+   * @namespace BDD
    * @api public
    */
 
@@ -2056,7 +1535,6 @@ module.exports = function (chai, _) {
    *     expect(fn).to.not.throw('good function');
    *     expect(fn).to.throw(ReferenceError, /bad function/);
    *     expect(fn).to.throw(err);
-   *     expect(fn).to.not.throw(new RangeError('Out of range.'));
    *
    * Please note that when a throw expectation is negated, it will check each
    * parameter independently, starting with error constructor type. The appropriate way
@@ -2074,6 +1552,7 @@ module.exports = function (chai, _) {
    * @param {String} message _optional_
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
    * @returns error for chaining (null if no error)
+   * @namespace BDD
    * @api public
    */
 
@@ -2098,9 +1577,9 @@ module.exports = function (chai, _) {
       constructor = null;
       errMsg = null;
     } else if (typeof constructor === 'function') {
-      name = constructor.prototype.name || constructor.name;
-      if (name === 'Error' && constructor !== Error) {
-        name = (new constructor()).name;
+      name = constructor.prototype.name;
+      if (!name || (name === 'Error' && constructor !== Error)) {
+        name = constructor.name || (new constructor()).name;
       }
     } else {
       constructor = null;
@@ -2140,7 +1619,7 @@ module.exports = function (chai, _) {
       }
 
       // next, check message
-      var message = 'object' === _.type(err) && "message" in err
+      var message = 'error' === _.type(err) && "message" in err
         ? err.message
         : '' + err;
 
@@ -2214,12 +1693,14 @@ module.exports = function (chai, _) {
    *     expect(Klass).itself.to.respondTo('baz');
    *
    * @name respondTo
+   * @alias respondsTo
    * @param {String} method
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
-  Assertion.addMethod('respondTo', function (method, msg) {
+  function respondTo (method, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object')
       , itself = flag(this, 'itself')
@@ -2232,7 +1713,10 @@ module.exports = function (chai, _) {
       , 'expected #{this} to respond to ' + _.inspect(method)
       , 'expected #{this} to not respond to ' + _.inspect(method)
     );
-  });
+  }
+
+  Assertion.addMethod('respondTo', respondTo);
+  Assertion.addMethod('respondsTo', respondTo);
 
   /**
    * ### .itself
@@ -2247,6 +1731,7 @@ module.exports = function (chai, _) {
    *     expect(Foo).itself.not.to.respondTo('baz');
    *
    * @name itself
+   * @namespace BDD
    * @api public
    */
 
@@ -2262,12 +1747,14 @@ module.exports = function (chai, _) {
    *     expect(1).to.satisfy(function(num) { return num > 0; });
    *
    * @name satisfy
+   * @alias satisfies
    * @param {Function} matcher
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
-  Assertion.addMethod('satisfy', function (matcher, msg) {
+  function satisfy (matcher, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
     var result = matcher(obj);
@@ -2278,7 +1765,10 @@ module.exports = function (chai, _) {
       , this.negate ? false : true
       , result
     );
-  });
+  }
+
+  Assertion.addMethod('satisfy', satisfy);
+  Assertion.addMethod('satisfies', satisfy);
 
   /**
    * ### .closeTo(expected, delta)
@@ -2288,19 +1778,21 @@ module.exports = function (chai, _) {
    *     expect(1.5).to.be.closeTo(1, 0.5);
    *
    * @name closeTo
+   * @alias approximately
    * @param {Number} expected
    * @param {Number} delta
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
-  Assertion.addMethod('closeTo', function (expected, delta, msg) {
+  function closeTo(expected, delta, msg) {
     if (msg) flag(this, 'message', msg);
     var obj = flag(this, 'object');
 
     new Assertion(obj, msg).is.a('number');
     if (_.type(expected) !== 'number' || _.type(delta) !== 'number') {
-      throw new Error('the arguments to closeTo must be numbers');
+      throw new Error('the arguments to closeTo or approximately must be numbers');
     }
 
     this.assert(
@@ -2308,7 +1800,10 @@ module.exports = function (chai, _) {
       , 'expected #{this} to be close to ' + expected + ' +/- ' + delta
       , 'expected #{this} not to be close to ' + expected + ' +/- ' + delta
     );
-  });
+  }
+
+  Assertion.addMethod('closeTo', closeTo);
+  Assertion.addMethod('approximately', closeTo);
 
   function isSubsetOf(subset, superset, cmp) {
     return subset.every(function(elem) {
@@ -2339,6 +1834,7 @@ module.exports = function (chai, _) {
    * @name members
    * @param {Array} set
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -2371,6 +1867,45 @@ module.exports = function (chai, _) {
   });
 
   /**
+   * ### .oneOf(list)
+   *
+   * Assert that a value appears somewhere in the top level of array `list`.
+   *
+   *     expect('a').to.be.oneOf(['a', 'b', 'c']);
+   *     expect(9).to.not.be.oneOf(['z']);
+   *     expect([3]).to.not.be.oneOf([1, 2, [3]]);
+   *
+   *     var three = [3];
+   *     // for object-types, contents are not compared
+   *     expect(three).to.not.be.oneOf([1, 2, [3]]);
+   *     // comparing references works
+   *     expect(three).to.be.oneOf([1, 2, three]);
+   *
+   * @name oneOf
+   * @param {Array<*>} list
+   * @param {String} message _optional_
+   * @namespace BDD
+   * @api public
+   */
+
+  function oneOf (list, msg) {
+    if (msg) flag(this, 'message', msg);
+    var expected = flag(this, 'object');
+    new Assertion(list).to.be.an('array');
+
+    this.assert(
+        list.indexOf(expected) > -1
+      , 'expected #{this} to be one of #{exp}'
+      , 'expected #{this} to not be one of #{exp}'
+      , list
+      , expected
+    );
+  }
+
+  Assertion.addMethod('oneOf', oneOf);
+
+
+  /**
    * ### .change(function)
    *
    * Asserts that a function changes an object property
@@ -2387,6 +1922,7 @@ module.exports = function (chai, _) {
    * @param {String} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -2424,6 +1960,7 @@ module.exports = function (chai, _) {
    * @param {String} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -2461,6 +1998,7 @@ module.exports = function (chai, _) {
    * @param {String} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace BDD
    * @api public
    */
 
@@ -2483,11 +2021,134 @@ module.exports = function (chai, _) {
   Assertion.addChainableMethod('decrease', assertDecreases);
   Assertion.addChainableMethod('decreases', assertDecreases);
 
+  /**
+   * ### .extensible
+   *
+   * Asserts that the target is extensible (can have new properties added to
+   * it).
+   *
+   *     var nonExtensibleObject = Object.preventExtensions({});
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect({}).to.be.extensible;
+   *     expect(nonExtensibleObject).to.not.be.extensible;
+   *     expect(sealedObject).to.not.be.extensible;
+   *     expect(frozenObject).to.not.be.extensible;
+   *
+   * @name extensible
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addProperty('extensible', function() {
+    var obj = flag(this, 'object');
+
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a non-extensible ordinary object, simply return false.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isExtensible;
+
+    try {
+      isExtensible = Object.isExtensible(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isExtensible = false;
+      else throw err;
+    }
+
+    this.assert(
+      isExtensible
+      , 'expected #{this} to be extensible'
+      , 'expected #{this} to not be extensible'
+    );
+  });
+
+  /**
+   * ### .sealed
+   *
+   * Asserts that the target is sealed (cannot have new properties added to it
+   * and its existing properties cannot be removed).
+   *
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect(sealedObject).to.be.sealed;
+   *     expect(frozenObject).to.be.sealed;
+   *     expect({}).to.not.be.sealed;
+   *
+   * @name sealed
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addProperty('sealed', function() {
+    var obj = flag(this, 'object');
+
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a sealed ordinary object, simply return true.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isSealed;
+
+    try {
+      isSealed = Object.isSealed(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isSealed = true;
+      else throw err;
+    }
+
+    this.assert(
+      isSealed
+      , 'expected #{this} to be sealed'
+      , 'expected #{this} to not be sealed'
+    );
+  });
+
+  /**
+   * ### .frozen
+   *
+   * Asserts that the target is frozen (cannot have new properties added to it
+   * and its existing properties cannot be modified).
+   *
+   *     var frozenObject = Object.freeze({});
+   *
+   *     expect(frozenObject).to.be.frozen;
+   *     expect({}).to.not.be.frozen;
+   *
+   * @name frozen
+   * @namespace BDD
+   * @api public
+   */
+
+  Assertion.addProperty('frozen', function() {
+    var obj = flag(this, 'object');
+
+    // In ES5, if the argument to this method is not an object (a primitive), then it will cause a TypeError.
+    // In ES6, a non-object argument will be treated as if it was a frozen ordinary object, simply return true.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
+    // The following provides ES6 behavior when a TypeError is thrown under ES5.
+
+    var isFrozen;
+
+    try {
+      isFrozen = Object.isFrozen(obj);
+    } catch (err) {
+      if (err instanceof TypeError) isFrozen = true;
+      else throw err;
+    }
+
+    this.assert(
+      isFrozen
+      , 'expected #{this} to be frozen'
+      , 'expected #{this} to not be frozen'
+    );
+  });
 };
 
-});
-
-require.register("chai/lib/chai/interface/assert.js", function (exports, module) {
+},{}],6:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011-2014 Jake Luer <jake@alogicalparadox.com>
@@ -2519,6 +2180,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} expression to test for truthiness
    * @param {String} message to display on error
    * @name assert
+   * @namespace Assert
    * @api public
    */
 
@@ -2541,6 +2203,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} expected
    * @param {String} message
    * @param {String} operator
+   * @namespace Assert
    * @api public
    */
 
@@ -2554,38 +2217,42 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .ok(object, [message])
+   * ### .isOk(object, [message])
    *
    * Asserts that `object` is truthy.
    *
-   *     assert.ok('everything', 'everything is ok');
-   *     assert.ok(false, 'this will fail');
+   *     assert.isOk('everything', 'everything is ok');
+   *     assert.isOk(false, 'this will fail');
    *
-   * @name ok
+   * @name isOk
+   * @alias ok
    * @param {Mixed} object to test
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
-  assert.ok = function (val, msg) {
+  assert.isOk = function (val, msg) {
     new Assertion(val, msg).is.ok;
   };
 
   /**
-   * ### .notOk(object, [message])
+   * ### .isNotOk(object, [message])
    *
    * Asserts that `object` is falsy.
    *
-   *     assert.notOk('everything', 'this will fail');
-   *     assert.notOk(false, 'this will pass');
+   *     assert.isNotOk('everything', 'this will fail');
+   *     assert.isNotOk(false, 'this will pass');
    *
-   * @name notOk
+   * @name isNotOk
+   * @alias notOk
    * @param {Mixed} object to test
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
-  assert.notOk = function (val, msg) {
+  assert.isNotOk = function (val, msg) {
     new Assertion(val, msg).is.not.ok;
   };
 
@@ -2600,6 +2267,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2626,6 +2294,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2652,6 +2321,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2670,6 +2340,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2688,6 +2359,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2706,29 +2378,12 @@ module.exports = function (chai, util) {
    * @param {Mixed} actual
    * @param {Mixed} expected
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.notDeepEqual = function (act, exp, msg) {
     new Assertion(act, msg).to.not.eql(exp);
-  };
-
-  /**
-   * ### .isTrue(value, [message])
-   *
-   * Asserts that `value` is true.
-   *
-   *     var teaServed = true;
-   *     assert.isTrue(teaServed, 'the tea has been served');
-   *
-   * @name isTrue
-   * @param {Mixed} value
-   * @param {String} message
-   * @api public
-   */
-
-  assert.isAbove = function (val, abv, msg) {
-    new Assertion(val, msg).to.be.above(abv);
   };
 
    /**
@@ -2742,11 +2397,32 @@ module.exports = function (chai, util) {
    * @param {Mixed} valueToCheck
    * @param {Mixed} valueToBeAbove
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
-  assert.isBelow = function (val, blw, msg) {
-    new Assertion(val, msg).to.be.below(blw);
+  assert.isAbove = function (val, abv, msg) {
+    new Assertion(val, msg).to.be.above(abv);
+  };
+
+   /**
+   * ### .isAtLeast(valueToCheck, valueToBeAtLeast, [message])
+   *
+   * Asserts `valueToCheck` is greater than or equal to (>=) `valueToBeAtLeast`
+   *
+   *     assert.isAtLeast(5, 2, '5 is greater or equal to 2');
+   *     assert.isAtLeast(3, 3, '3 is greater or equal to 3');
+   *
+   * @name isAtLeast
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeAtLeast
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isAtLeast = function (val, atlst, msg) {
+    new Assertion(val, msg).to.be.least(atlst);
   };
 
    /**
@@ -2760,11 +2436,70 @@ module.exports = function (chai, util) {
    * @param {Mixed} valueToCheck
    * @param {Mixed} valueToBeBelow
    * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isBelow = function (val, blw, msg) {
+    new Assertion(val, msg).to.be.below(blw);
+  };
+
+   /**
+   * ### .isAtMost(valueToCheck, valueToBeAtMost, [message])
+   *
+   * Asserts `valueToCheck` is less than or equal to (<=) `valueToBeAtMost`
+   *
+   *     assert.isAtMost(3, 6, '3 is less than or equal to 6');
+   *     assert.isAtMost(4, 4, '4 is less than or equal to 4');
+   *
+   * @name isAtMost
+   * @param {Mixed} valueToCheck
+   * @param {Mixed} valueToBeAtMost
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isAtMost = function (val, atmst, msg) {
+    new Assertion(val, msg).to.be.most(atmst);
+  };
+
+  /**
+   * ### .isTrue(value, [message])
+   *
+   * Asserts that `value` is true.
+   *
+   *     var teaServed = true;
+   *     assert.isTrue(teaServed, 'the tea has been served');
+   *
+   * @name isTrue
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.isTrue = function (val, msg) {
     new Assertion(val, msg).is['true'];
+  };
+
+  /**
+   * ### .isNotTrue(value, [message])
+   *
+   * Asserts that `value` is not true.
+   *
+   *     var tea = 'tasty chai';
+   *     assert.isNotTrue(tea, 'great, time for tea!');
+   *
+   * @name isNotTrue
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNotTrue = function (val, msg) {
+    new Assertion(val, msg).to.not.equal(true);
   };
 
   /**
@@ -2778,11 +2513,31 @@ module.exports = function (chai, util) {
    * @name isFalse
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.isFalse = function (val, msg) {
     new Assertion(val, msg).is['false'];
+  };
+
+  /**
+   * ### .isNotFalse(value, [message])
+   *
+   * Asserts that `value` is not false.
+   *
+   *     var tea = 'tasty chai';
+   *     assert.isNotFalse(tea, 'great, time for tea!');
+   *
+   * @name isNotFalse
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNotFalse = function (val, msg) {
+    new Assertion(val, msg).to.not.equal(false);
   };
 
   /**
@@ -2795,6 +2550,7 @@ module.exports = function (chai, util) {
    * @name isNull
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2813,11 +2569,45 @@ module.exports = function (chai, util) {
    * @name isNotNull
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.isNotNull = function (val, msg) {
     new Assertion(val, msg).to.not.equal(null);
+  };
+
+  /**
+   * ### .isNaN
+   * Asserts that value is NaN
+   *
+   *    assert.isNaN('foo', 'foo is NaN');
+   *
+   * @name isNaN
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNaN = function (val, msg) {
+    new Assertion(val, msg).to.be.NaN;
+  };
+
+  /**
+   * ### .isNotNaN
+   * Asserts that value is not NaN
+   *
+   *    assert.isNotNaN(4, '4 is not NaN');
+   *
+   * @name isNotNaN
+   * @param {Mixed} value
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+  assert.isNotNaN = function (val, msg) {
+    new Assertion(val, msg).not.to.be.NaN;
   };
 
   /**
@@ -2831,6 +2621,7 @@ module.exports = function (chai, util) {
    * @name isUndefined
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2849,6 +2640,7 @@ module.exports = function (chai, util) {
    * @name isDefined
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2867,6 +2659,7 @@ module.exports = function (chai, util) {
    * @name isFunction
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2885,6 +2678,7 @@ module.exports = function (chai, util) {
    * @name isNotFunction
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2904,6 +2698,7 @@ module.exports = function (chai, util) {
    * @name isObject
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2923,6 +2718,7 @@ module.exports = function (chai, util) {
    * @name isNotObject
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2941,6 +2737,7 @@ module.exports = function (chai, util) {
    * @name isArray
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2959,6 +2756,7 @@ module.exports = function (chai, util) {
    * @name isNotArray
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2977,6 +2775,7 @@ module.exports = function (chai, util) {
    * @name isString
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -2995,6 +2794,7 @@ module.exports = function (chai, util) {
    * @name isNotString
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3013,6 +2813,7 @@ module.exports = function (chai, util) {
    * @name isNumber
    * @param {Number} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3031,6 +2832,7 @@ module.exports = function (chai, util) {
    * @name isNotNumber
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3052,6 +2854,7 @@ module.exports = function (chai, util) {
    * @name isBoolean
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3073,6 +2876,7 @@ module.exports = function (chai, util) {
    * @name isNotBoolean
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3097,6 +2901,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} value
    * @param {String} name
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3116,6 +2921,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} value
    * @param {String} typeof name
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3137,6 +2943,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {Constructor} constructor
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3158,6 +2965,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {Constructor} constructor
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3178,6 +2986,7 @@ module.exports = function (chai, util) {
    * @param {Array|String} haystack
    * @param {Mixed} needle
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3190,7 +2999,7 @@ module.exports = function (chai, util) {
    *
    * Asserts that `haystack` does not include `needle`. Works
    * for strings and arrays.
-   *i
+   *
    *     assert.notInclude('foobar', 'baz', 'string not include substring');
    *     assert.notInclude([ 1, 2, 3 ], 4, 'array not include contain value');
    *
@@ -3198,6 +3007,7 @@ module.exports = function (chai, util) {
    * @param {Array|String} haystack
    * @param {Mixed} needle
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3216,6 +3026,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} value
    * @param {RegExp} regexp
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3234,6 +3045,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} value
    * @param {RegExp} regexp
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3252,6 +3064,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3270,6 +3083,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3289,6 +3103,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3308,6 +3123,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3328,6 +3144,7 @@ module.exports = function (chai, util) {
    * @param {String} property
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3348,6 +3165,7 @@ module.exports = function (chai, util) {
    * @param {String} property
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3369,6 +3187,7 @@ module.exports = function (chai, util) {
    * @param {String} property
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3390,6 +3209,7 @@ module.exports = function (chai, util) {
    * @param {String} property
    * @param {Mixed} value
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3403,12 +3223,13 @@ module.exports = function (chai, util) {
    * Asserts that `object` has a `length` property with the expected value.
    *
    *     assert.lengthOf([1,2,3], 3, 'array has length of 3');
-   *     assert.lengthOf('foobar', 5, 'string has length of 6');
+   *     assert.lengthOf('foobar', 6, 'string has length of 6');
    *
    * @name lengthOf
    * @param {Mixed} object
    * @param {Number} length
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3423,11 +3244,11 @@ module.exports = function (chai, util) {
    * `constructor`, or alternately that it will throw an error with message
    * matching `regexp`.
    *
-   *     assert.throw(fn, 'function throws a reference error');
-   *     assert.throw(fn, /function throws a reference error/);
-   *     assert.throw(fn, ReferenceError);
-   *     assert.throw(fn, ReferenceError, 'function throws a reference error');
-   *     assert.throw(fn, ReferenceError, /function throws a reference error/);
+   *     assert.throws(fn, 'function throws a reference error');
+   *     assert.throws(fn, /function throws a reference error/);
+   *     assert.throws(fn, ReferenceError);
+   *     assert.throws(fn, ReferenceError, 'function throws a reference error');
+   *     assert.throws(fn, ReferenceError, /function throws a reference error/);
    *
    * @name throws
    * @alias throw
@@ -3437,16 +3258,17 @@ module.exports = function (chai, util) {
    * @param {RegExp} regexp
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
+   * @namespace Assert
    * @api public
    */
 
-  assert.Throw = function (fn, errt, errs, msg) {
+  assert.throws = function (fn, errt, errs, msg) {
     if ('string' === typeof errt || errt instanceof RegExp) {
       errs = errt;
       errt = null;
     }
 
-    var assertErr = new Assertion(fn, msg).to.Throw(errt, errs);
+    var assertErr = new Assertion(fn, msg).to.throw(errt, errs);
     return flag(assertErr, 'object');
   };
 
@@ -3465,6 +3287,7 @@ module.exports = function (chai, util) {
    * @param {RegExp} regexp
    * @param {String} message
    * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
+   * @namespace Assert
    * @api public
    */
 
@@ -3490,14 +3313,41 @@ module.exports = function (chai, util) {
    * @param {String} operator
    * @param {Mixed} val2
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.operator = function (val, operator, val2, msg) {
-    if (!~['==', '===', '>', '>=', '<', '<=', '!=', '!=='].indexOf(operator)) {
-      throw new Error('Invalid operator "' + operator + '"');
+    var ok;
+    switch(operator) {
+      case '==':
+        ok = val == val2;
+        break;
+      case '===':
+        ok = val === val2;
+        break;
+      case '>':
+        ok = val > val2;
+        break;
+      case '>=':
+        ok = val >= val2;
+        break;
+      case '<':
+        ok = val < val2;
+        break;
+      case '<=':
+        ok = val <= val2;
+        break;
+      case '!=':
+        ok = val != val2;
+        break;
+      case '!==':
+        ok = val !== val2;
+        break;
+      default:
+        throw new Error('Invalid operator "' + operator + '"');
     }
-    var test = new Assertion(eval(val + operator + val2), msg);
+    var test = new Assertion(ok, msg);
     test.assert(
         true === flag(test, 'object')
       , 'expected ' + util.inspect(val) + ' to be ' + operator + ' ' + util.inspect(val2)
@@ -3516,11 +3366,32 @@ module.exports = function (chai, util) {
    * @param {Number} expected
    * @param {Number} delta
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.closeTo = function (act, exp, delta, msg) {
     new Assertion(act, msg).to.be.closeTo(exp, delta);
+  };
+
+  /**
+   * ### .approximately(actual, expected, delta, [message])
+   *
+   * Asserts that the target is equal `expected`, to within a +/- `delta` range.
+   *
+   *     assert.approximately(1.5, 1, 0.5, 'numbers are close');
+   *
+   * @name approximately
+   * @param {Number} actual
+   * @param {Number} expected
+   * @param {Number} delta
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.approximately = function (act, exp, delta, msg) {
+    new Assertion(act, msg).to.be.approximately(exp, delta);
   };
 
   /**
@@ -3535,6 +3406,7 @@ module.exports = function (chai, util) {
    * @param {Array} set1
    * @param {Array} set2
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3554,6 +3426,7 @@ module.exports = function (chai, util) {
    * @param {Array} set1
    * @param {Array} set2
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
@@ -3573,11 +3446,31 @@ module.exports = function (chai, util) {
    * @param {Array} superset
    * @param {Array} subset
    * @param {String} message
+   * @namespace Assert
    * @api public
    */
 
   assert.includeMembers = function (superset, subset, msg) {
     new Assertion(superset, msg).to.include.members(subset);
+  }
+
+  /**
+   * ### .oneOf(inList, list, [message])
+   *
+   * Asserts that non-object, non-array value `inList` appears in the flat array `list`.
+   *
+   *     assert.oneOf(1, [ 2, 1 ], 'Not found in list');
+   *
+   * @name oneOf
+   * @param {*} inList
+   * @param {Array<*>} list
+   * @param {String} message
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.oneOf = function (inList, list, msg) {
+    new Assertion(inList, msg).to.be.oneOf(list);
   }
 
    /**
@@ -3594,6 +3487,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3615,6 +3509,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3636,6 +3531,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3657,6 +3553,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3678,6 +3575,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3699,6 +3597,7 @@ module.exports = function (chai, util) {
    * @param {Object} object
    * @param {String} property name
    * @param {String} message _optional_
+   * @namespace Assert
    * @api public
    */
 
@@ -3707,11 +3606,152 @@ module.exports = function (chai, util) {
   }
 
   /*!
-   * Undocumented / untested
+   * ### .ifError(object)
+   *
+   * Asserts if value is not a false value, and throws if it is a true value.
+   * This is added to allow for chai to be a drop-in replacement for Node's
+   * assert class.
+   *
+   *     var err = new Error('I am a custom error');
+   *     assert.ifError(err); // Rethrows err!
+   *
+   * @name ifError
+   * @param {Object} object
+   * @namespace Assert
+   * @api public
    */
 
-  assert.ifError = function (val, msg) {
-    new Assertion(val, msg).to.not.be.ok;
+  assert.ifError = function (val) {
+    if (val) {
+      throw(val);
+    }
+  };
+
+  /**
+   * ### .isExtensible(object)
+   *
+   * Asserts that `object` is extensible (can have new properties added to it).
+   *
+   *     assert.isExtensible({});
+   *
+   * @name isExtensible
+   * @alias extensible
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isExtensible = function (obj, msg) {
+    new Assertion(obj, msg).to.be.extensible;
+  };
+
+  /**
+   * ### .isNotExtensible(object)
+   *
+   * Asserts that `object` is _not_ extensible.
+   *
+   *     var nonExtensibleObject = Object.preventExtensions({});
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.freese({});
+   *
+   *     assert.isNotExtensible(nonExtensibleObject);
+   *     assert.isNotExtensible(sealedObject);
+   *     assert.isNotExtensible(frozenObject);
+   *
+   * @name isNotExtensible
+   * @alias notExtensible
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNotExtensible = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.extensible;
+  };
+
+  /**
+   * ### .isSealed(object)
+   *
+   * Asserts that `object` is sealed (cannot have new properties added to it
+   * and its existing properties cannot be removed).
+   *
+   *     var sealedObject = Object.seal({});
+   *     var frozenObject = Object.seal({});
+   *
+   *     assert.isSealed(sealedObject);
+   *     assert.isSealed(frozenObject);
+   *
+   * @name isSealed
+   * @alias sealed
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isSealed = function (obj, msg) {
+    new Assertion(obj, msg).to.be.sealed;
+  };
+
+  /**
+   * ### .isNotSealed(object)
+   *
+   * Asserts that `object` is _not_ sealed.
+   *
+   *     assert.isNotSealed({});
+   *
+   * @name isNotSealed
+   * @alias notSealed
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNotSealed = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.sealed;
+  };
+
+  /**
+   * ### .isFrozen(object)
+   *
+   * Asserts that `object` is frozen (cannot have new properties added to it
+   * and its existing properties cannot be modified).
+   *
+   *     var frozenObject = Object.freeze({});
+   *     assert.frozen(frozenObject);
+   *
+   * @name isFrozen
+   * @alias frozen
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isFrozen = function (obj, msg) {
+    new Assertion(obj, msg).to.be.frozen;
+  };
+
+  /**
+   * ### .isNotFrozen(object)
+   *
+   * Asserts that `object` is _not_ frozen.
+   *
+   *     assert.isNotFrozen({});
+   *
+   * @name isNotFrozen
+   * @alias notFrozen
+   * @param {Object} object
+   * @param {String} message _optional_
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.isNotFrozen = function (obj, msg) {
+    new Assertion(obj, msg).to.not.be.frozen;
   };
 
   /*!
@@ -3722,13 +3762,19 @@ module.exports = function (chai, util) {
     assert[as] = assert[name];
     return alias;
   })
-  ('Throw', 'throw')
-  ('Throw', 'throws');
+  ('isOk', 'ok')
+  ('isNotOk', 'notOk')
+  ('throws', 'throw')
+  ('throws', 'Throw')
+  ('isExtensible', 'extensible')
+  ('isNotExtensible', 'notExtensible')
+  ('isSealed', 'sealed')
+  ('isNotSealed', 'notSealed')
+  ('isFrozen', 'frozen')
+  ('isNotFrozen', 'notFrozen');
 };
 
-});
-
-require.register("chai/lib/chai/interface/expect.js", function (exports, module) {
+},{}],7:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011-2014 Jake Luer <jake@alogicalparadox.com>
@@ -3750,6 +3796,7 @@ module.exports = function (chai, util) {
    * @param {Mixed} expected
    * @param {String} message
    * @param {String} operator
+   * @namespace Expect
    * @api public
    */
 
@@ -3763,9 +3810,7 @@ module.exports = function (chai, util) {
   };
 };
 
-});
-
-require.register("chai/lib/chai/interface/should.js", function (exports, module) {
+},{}],8:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011-2014 Jake Luer <jake@alogicalparadox.com>
@@ -3778,10 +3823,8 @@ module.exports = function (chai, util) {
   function loadShould () {
     // explicitly define this method as function as to have it's name to include as `ssfi`
     function shouldGetter() {
-      if (this instanceof String || this instanceof Number) {
-        return new Assertion(this.constructor(this), null, shouldGetter);
-      } else if (this instanceof Boolean) {
-        return new Assertion(this == true, null, shouldGetter);
+      if (this instanceof String || this instanceof Number || this instanceof Boolean ) {
+        return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);
     }
@@ -3818,6 +3861,7 @@ module.exports = function (chai, util) {
      * @param {Mixed} expected
      * @param {String} message
      * @param {String} operator
+     * @namespace Should
      * @api public
      */
 
@@ -3867,9 +3911,7 @@ module.exports = function (chai, util) {
   chai.Should = loadShould;
 };
 
-});
-
-require.register("chai/lib/chai/utils/addChainableMethod.js", function (exports, module) {
+},{}],9:[function(require,module,exports){
 /*!
  * Chai - addChainingMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -3880,9 +3922,9 @@ require.register("chai/lib/chai/utils/addChainableMethod.js", function (exports,
  * Module dependencies
  */
 
-var transferFlags = require('chai/lib/chai/utils/transferFlags.js');
-var flag = require('chai/lib/chai/utils/flag.js');
-var config = require('chai/lib/chai/config.js');
+var transferFlags = require('./transferFlags');
+var flag = require('./flag');
+var config = require('../config');
 
 /*!
  * Module variables
@@ -3924,6 +3966,7 @@ var call  = Function.prototype.call,
  * @param {String} name of method to add
  * @param {Function} method function to be used for `name`, when called
  * @param {Function} chainingBehavior function to be called every time the property is accessed
+ * @namespace Utils
  * @name addChainableMethod
  * @api public
  */
@@ -3982,16 +4025,14 @@ module.exports = function (ctx, name, method, chainingBehavior) {
   });
 };
 
-});
-
-require.register("chai/lib/chai/utils/addMethod.js", function (exports, module) {
+},{"../config":4,"./flag":13,"./transferFlags":29}],10:[function(require,module,exports){
 /*!
  * Chai - addMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
  */
 
-var config = require('chai/lib/chai/config.js');
+var config = require('../config');
 
 /**
  * ### .addMethod (ctx, name, method)
@@ -4014,10 +4055,11 @@ var config = require('chai/lib/chai/config.js');
  * @param {Object} ctx object to which the method is added
  * @param {String} name of method to add
  * @param {Function} method function to be used for name
+ * @namespace Utils
  * @name addMethod
  * @api public
  */
-var flag = require('chai/lib/chai/utils/flag.js');
+var flag = require('./flag');
 
 module.exports = function (ctx, name, method) {
   ctx[name] = function () {
@@ -4029,14 +4071,15 @@ module.exports = function (ctx, name, method) {
   };
 };
 
-});
-
-require.register("chai/lib/chai/utils/addProperty.js", function (exports, module) {
+},{"../config":4,"./flag":13}],11:[function(require,module,exports){
 /*!
  * Chai - addProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
  */
+
+var config = require('../config');
+var flag = require('./flag');
 
 /**
  * ### addProperty (ctx, name, getter)
@@ -4059,13 +4102,18 @@ require.register("chai/lib/chai/utils/addProperty.js", function (exports, module
  * @param {Object} ctx object to which the property is added
  * @param {String} name of property to add
  * @param {Function} getter function to be used for name
+ * @namespace Utils
  * @name addProperty
  * @api public
  */
 
 module.exports = function (ctx, name, getter) {
   Object.defineProperty(ctx, name,
-    { get: function () {
+    { get: function addProperty() {
+        var old_ssfi = flag(this, 'ssfi');
+        if (old_ssfi && config.includeStack === false)
+          flag(this, 'ssfi', addProperty);
+
         var result = getter.call(this);
         return result === undefined ? this : result;
       }
@@ -4073,9 +4121,51 @@ module.exports = function (ctx, name, getter) {
   });
 };
 
-});
+},{"../config":4,"./flag":13}],12:[function(require,module,exports){
+/*!
+ * Chai - expectTypes utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
 
-require.register("chai/lib/chai/utils/flag.js", function (exports, module) {
+/**
+ * ### expectTypes(obj, types)
+ *
+ * Ensures that the object being tested against is of a valid type.
+ *
+ *     utils.expectTypes(this, ['array', 'object', 'string']);
+ *
+ * @param {Mixed} obj constructed Assertion
+ * @param {Array} type A list of allowed types for this assertion
+ * @namespace Utils
+ * @name expectTypes
+ * @api public
+ */
+
+var AssertionError = require('assertion-error');
+var flag = require('./flag');
+var type = require('type-detect');
+
+module.exports = function (obj, types) {
+  var obj = flag(obj, 'object');
+  types = types.map(function (t) { return t.toLowerCase(); });
+  types.sort();
+
+  // Transforms ['lorem', 'ipsum'] into 'a lirum, or an ipsum'
+  var str = types.map(function (t, index) {
+    var art = ~[ 'a', 'e', 'i', 'o', 'u' ].indexOf(t.charAt(0)) ? 'an' : 'a';
+    var or = types.length > 1 && index === types.length - 1 ? 'or ' : '';
+    return or + art + ' ' + t;
+  }).join(', ');
+
+  if (!types.some(function (expected) { return type(obj) === expected; })) {
+    throw new AssertionError(
+      'object tested must be ' + str + ', but ' + type(obj) + ' given'
+    );
+  }
+};
+
+},{"./flag":13,"assertion-error":30,"type-detect":35}],13:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4096,6 +4186,7 @@ require.register("chai/lib/chai/utils/flag.js", function (exports, module) {
  * @param {Object} object constructed Assertion
  * @param {String} key
  * @param {Mixed} value (optional)
+ * @namespace Utils
  * @name flag
  * @api private
  */
@@ -4109,9 +4200,7 @@ module.exports = function (obj, key, value) {
   }
 };
 
-});
-
-require.register("chai/lib/chai/utils/getActual.js", function (exports, module) {
+},{}],14:[function(require,module,exports){
 /*!
  * Chai - getActual utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4125,15 +4214,15 @@ require.register("chai/lib/chai/utils/getActual.js", function (exports, module) 
  *
  * @param {Object} object (constructed Assertion)
  * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name getActual
  */
 
 module.exports = function (obj, args) {
   return args.length > 4 ? args[4] : obj._obj;
 };
 
-});
-
-require.register("chai/lib/chai/utils/getEnumerableProperties.js", function (exports, module) {
+},{}],15:[function(require,module,exports){
 /*!
  * Chai - getEnumerableProperties utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4148,6 +4237,7 @@ require.register("chai/lib/chai/utils/getEnumerableProperties.js", function (exp
  *
  * @param {Object} object
  * @returns {Array}
+ * @namespace Utils
  * @name getEnumerableProperties
  * @api public
  */
@@ -4160,9 +4250,7 @@ module.exports = function getEnumerableProperties(object) {
   return result;
 };
 
-});
-
-require.register("chai/lib/chai/utils/getMessage.js", function (exports, module) {
+},{}],16:[function(require,module,exports){
 /*!
  * Chai - message composition utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4173,10 +4261,10 @@ require.register("chai/lib/chai/utils/getMessage.js", function (exports, module)
  * Module dependancies
  */
 
-var flag = require('chai/lib/chai/utils/flag.js')
-  , getActual = require('chai/lib/chai/utils/getActual.js')
-  , inspect = require('chai/lib/chai/utils/inspect.js')
-  , objDisplay = require('chai/lib/chai/utils/objDisplay.js');
+var flag = require('./flag')
+  , getActual = require('./getActual')
+  , inspect = require('./inspect')
+  , objDisplay = require('./objDisplay');
 
 /**
  * ### .getMessage(object, message, negateMessage)
@@ -4192,6 +4280,7 @@ var flag = require('chai/lib/chai/utils/flag.js')
  *
  * @param {Object} object (constructed Assertion)
  * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
  * @name getMessage
  * @api public
  */
@@ -4214,9 +4303,7 @@ module.exports = function (obj, args) {
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };
 
-});
-
-require.register("chai/lib/chai/utils/getName.js", function (exports, module) {
+},{"./flag":13,"./getActual":14,"./inspect":23,"./objDisplay":24}],17:[function(require,module,exports){
 /*!
  * Chai - getName utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4229,6 +4316,8 @@ require.register("chai/lib/chai/utils/getName.js", function (exports, module) {
  * Gets the name of a function, in a cross-browser way.
  *
  * @param {Function} a function (usually a constructor)
+ * @namespace Utils
+ * @name getName
  */
 
 module.exports = function (func) {
@@ -4238,62 +4327,14 @@ module.exports = function (func) {
   return match && match[1] ? match[1] : "";
 };
 
-});
-
-require.register("chai/lib/chai/utils/getPathValue.js", function (exports, module) {
-/*!
- * Chai - getPathValue utility
- * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
- * @see https://github.com/logicalparadox/filtr
- * MIT Licensed
- */
-
-var getPathInfo = require('chai/lib/chai/utils/getPathInfo.js');
-
-/**
- * ### .getPathValue(path, object)
- *
- * This allows the retrieval of values in an
- * object given a string path.
- *
- *     var obj = {
- *         prop1: {
- *             arr: ['a', 'b', 'c']
- *           , str: 'Hello'
- *         }
- *       , prop2: {
- *             arr: [ { nested: 'Universe' } ]
- *           , str: 'Hello again!'
- *         }
- *     }
- *
- * The following would be the results.
- *
- *     getPathValue('prop1.str', obj); // Hello
- *     getPathValue('prop1.att[2]', obj); // b
- *     getPathValue('prop2.arr[0].nested', obj); // Universe
- *
- * @param {String} path
- * @param {Object} object
- * @returns {Object} value or `undefined`
- * @name getPathValue
- * @api public
- */
-module.exports = function(path, obj) {
-  var info = getPathInfo(path, obj);
-  return info.value;
-}; 
-
-});
-
-require.register("chai/lib/chai/utils/getPathInfo.js", function (exports, module) {
+},{}],18:[function(require,module,exports){
 /*!
  * Chai - getPathInfo utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
  */
 
-var hasProperty = require('chai/lib/chai/utils/hasProperty.js');
+var hasProperty = require('./hasProperty');
 
 /**
  * ### .getPathInfo(path, object)
@@ -4312,6 +4353,7 @@ var hasProperty = require('chai/lib/chai/utils/hasProperty.js');
  * @param {String} path
  * @param {Object} object
  * @returns {Object} info
+ * @namespace Utils
  * @name getPathInfo
  * @api public
  */
@@ -4321,9 +4363,9 @@ module.exports = function getPathInfo(path, obj) {
       last = parsed[parsed.length - 1];
 
   var info = {
-    parent: _getPathValue(parsed, obj, parsed.length - 1),
+    parent: parsed.length > 1 ? _getPathValue(parsed, obj, parsed.length - 1) : obj,
     name: last.p || last.i,
-    value: _getPathValue(parsed, obj),
+    value: _getPathValue(parsed, obj)
   };
   info.exists = hasProperty(info.name, info.parent);
 
@@ -4343,6 +4385,7 @@ module.exports = function getPathInfo(path, obj) {
  *
  * * Can be as near infinitely deep and nested
  * * Arrays are also valid using the formal `myobject.document[3].property`.
+ * * Literal dots and brackets (not delimiter) must be backslash-escaped.
  *
  * @param {String} path
  * @returns {Object} parsed
@@ -4350,13 +4393,13 @@ module.exports = function getPathInfo(path, obj) {
  */
 
 function parsePath (path) {
-  var str = path.replace(/\[/g, '.[')
+  var str = path.replace(/([^\\])\[/g, '$1.[')
     , parts = str.match(/(\\\.|[^.]+?)+/g);
   return parts.map(function (value) {
-    var re = /\[(\d+)\]$/
+    var re = /^\[(\d+)\]$/
       , mArr = re.exec(value);
     if (mArr) return { i: parseFloat(mArr[1]) };
-    else return { p: value };
+    else return { p: value.replace(/\\([.\[\]])/g, '$1') };
   });
 }
 
@@ -4397,16 +4440,97 @@ function _getPathValue (parsed, obj, index) {
   return res;
 }
 
-});
+},{"./hasProperty":21}],19:[function(require,module,exports){
+/*!
+ * Chai - getPathValue utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * @see https://github.com/logicalparadox/filtr
+ * MIT Licensed
+ */
 
-require.register("chai/lib/chai/utils/hasProperty.js", function (exports, module) {
+var getPathInfo = require('./getPathInfo');
+
+/**
+ * ### .getPathValue(path, object)
+ *
+ * This allows the retrieval of values in an
+ * object given a string path.
+ *
+ *     var obj = {
+ *         prop1: {
+ *             arr: ['a', 'b', 'c']
+ *           , str: 'Hello'
+ *         }
+ *       , prop2: {
+ *             arr: [ { nested: 'Universe' } ]
+ *           , str: 'Hello again!'
+ *         }
+ *     }
+ *
+ * The following would be the results.
+ *
+ *     getPathValue('prop1.str', obj); // Hello
+ *     getPathValue('prop1.att[2]', obj); // b
+ *     getPathValue('prop2.arr[0].nested', obj); // Universe
+ *
+ * @param {String} path
+ * @param {Object} object
+ * @returns {Object} value or `undefined`
+ * @namespace Utils
+ * @name getPathValue
+ * @api public
+ */
+module.exports = function(path, obj) {
+  var info = getPathInfo(path, obj);
+  return info.value;
+};
+
+},{"./getPathInfo":18}],20:[function(require,module,exports){
+/*!
+ * Chai - getProperties utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/**
+ * ### .getProperties(object)
+ *
+ * This allows the retrieval of property names of an object, enumerable or not,
+ * inherited or not.
+ *
+ * @param {Object} object
+ * @returns {Array}
+ * @namespace Utils
+ * @name getProperties
+ * @api public
+ */
+
+module.exports = function getProperties(object) {
+  var result = Object.getOwnPropertyNames(object);
+
+  function addProperty(property) {
+    if (result.indexOf(property) === -1) {
+      result.push(property);
+    }
+  }
+
+  var proto = Object.getPrototypeOf(object);
+  while (proto !== null) {
+    Object.getOwnPropertyNames(proto).forEach(addProperty);
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return result;
+};
+
+},{}],21:[function(require,module,exports){
 /*!
  * Chai - hasProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
  */
 
-var type = require('chai/lib/chai/utils/type.js');
+var type = require('type-detect');
 
 /**
  * ### .hasProperty(object, name)
@@ -4428,7 +4552,7 @@ var type = require('chai/lib/chai/utils/type.js');
  *     hasProperty('str', obj);  // true
  *     hasProperty('constructor', obj);  // true
  *     hasProperty('bar', obj);  // false
- *     
+ *
  *     hasProperty('length', obj.str); // true
  *     hasProperty(1, obj.str);  // true
  *     hasProperty(5, obj.str);  // false
@@ -4440,6 +4564,7 @@ var type = require('chai/lib/chai/utils/type.js');
  * @param {Objuect} object
  * @param {String|Number} name
  * @returns {Boolean} whether it exists
+ * @namespace Utils
  * @name getPathInfo
  * @api public
  */
@@ -4464,48 +4589,7 @@ module.exports = function hasProperty(name, obj) {
   return name in obj;
 };
 
-});
-
-require.register("chai/lib/chai/utils/getProperties.js", function (exports, module) {
-/*!
- * Chai - getProperties utility
- * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
- * MIT Licensed
- */
-
-/**
- * ### .getProperties(object)
- *
- * This allows the retrieval of property names of an object, enumerable or not,
- * inherited or not.
- *
- * @param {Object} object
- * @returns {Array}
- * @name getProperties
- * @api public
- */
-
-module.exports = function getProperties(object) {
-  var result = Object.getOwnPropertyNames(subject);
-
-  function addProperty(property) {
-    if (result.indexOf(property) === -1) {
-      result.push(property);
-    }
-  }
-
-  var proto = Object.getPrototypeOf(subject);
-  while (proto !== null) {
-    Object.getOwnPropertyNames(proto).forEach(addProperty);
-    proto = Object.getPrototypeOf(proto);
-  }
-
-  return result;
-};
-
-});
-
-require.register("chai/lib/chai/utils/index.js", function (exports, module) {
+},{"type-detect":35}],22:[function(require,module,exports){
 /*!
  * chai
  * Copyright(c) 2011 Jake Luer <jake@alogicalparadox.com>
@@ -4522,126 +4606,128 @@ var exports = module.exports = {};
  * test utility
  */
 
-exports.test = require('chai/lib/chai/utils/test.js');
+exports.test = require('./test');
 
 /*!
  * type utility
  */
 
-exports.type = require('chai/lib/chai/utils/type.js');
+exports.type = require('type-detect');
+
+/*!
+ * expectTypes utility
+ */
+exports.expectTypes = require('./expectTypes');
 
 /*!
  * message utility
  */
 
-exports.getMessage = require('chai/lib/chai/utils/getMessage.js');
+exports.getMessage = require('./getMessage');
 
 /*!
  * actual utility
  */
 
-exports.getActual = require('chai/lib/chai/utils/getActual.js');
+exports.getActual = require('./getActual');
 
 /*!
  * Inspect util
  */
 
-exports.inspect = require('chai/lib/chai/utils/inspect.js');
+exports.inspect = require('./inspect');
 
 /*!
  * Object Display util
  */
 
-exports.objDisplay = require('chai/lib/chai/utils/objDisplay.js');
+exports.objDisplay = require('./objDisplay');
 
 /*!
  * Flag utility
  */
 
-exports.flag = require('chai/lib/chai/utils/flag.js');
+exports.flag = require('./flag');
 
 /*!
  * Flag transferring utility
  */
 
-exports.transferFlags = require('chai/lib/chai/utils/transferFlags.js');
+exports.transferFlags = require('./transferFlags');
 
 /*!
  * Deep equal utility
  */
 
-exports.eql = require('chaijs~deep-eql@0.1.3');
+exports.eql = require('deep-eql');
 
 /*!
  * Deep path value
  */
 
-exports.getPathValue = require('chai/lib/chai/utils/getPathValue.js');
+exports.getPathValue = require('./getPathValue');
 
 /*!
  * Deep path info
  */
 
-exports.getPathInfo = require('chai/lib/chai/utils/getPathInfo.js');
+exports.getPathInfo = require('./getPathInfo');
 
 /*!
  * Check if a property exists
  */
 
-exports.hasProperty = require('chai/lib/chai/utils/hasProperty.js');
+exports.hasProperty = require('./hasProperty');
 
 /*!
  * Function name
  */
 
-exports.getName = require('chai/lib/chai/utils/getName.js');
+exports.getName = require('./getName');
 
 /*!
  * add Property
  */
 
-exports.addProperty = require('chai/lib/chai/utils/addProperty.js');
+exports.addProperty = require('./addProperty');
 
 /*!
  * add Method
  */
 
-exports.addMethod = require('chai/lib/chai/utils/addMethod.js');
+exports.addMethod = require('./addMethod');
 
 /*!
  * overwrite Property
  */
 
-exports.overwriteProperty = require('chai/lib/chai/utils/overwriteProperty.js');
+exports.overwriteProperty = require('./overwriteProperty');
 
 /*!
  * overwrite Method
  */
 
-exports.overwriteMethod = require('chai/lib/chai/utils/overwriteMethod.js');
+exports.overwriteMethod = require('./overwriteMethod');
 
 /*!
  * Add a chainable method
  */
 
-exports.addChainableMethod = require('chai/lib/chai/utils/addChainableMethod.js');
+exports.addChainableMethod = require('./addChainableMethod');
 
 /*!
  * Overwrite chainable method
  */
 
-exports.overwriteChainableMethod = require('chai/lib/chai/utils/overwriteChainableMethod.js');
+exports.overwriteChainableMethod = require('./overwriteChainableMethod');
 
-
-});
-
-require.register("chai/lib/chai/utils/inspect.js", function (exports, module) {
+},{"./addChainableMethod":9,"./addMethod":10,"./addProperty":11,"./expectTypes":12,"./flag":13,"./getActual":14,"./getMessage":16,"./getName":17,"./getPathInfo":18,"./getPathValue":19,"./hasProperty":21,"./inspect":23,"./objDisplay":24,"./overwriteChainableMethod":25,"./overwriteMethod":26,"./overwriteProperty":27,"./test":28,"./transferFlags":29,"deep-eql":31,"type-detect":35}],23:[function(require,module,exports){
 // This is (almost) directly from Node.js utils
 // https://github.com/joyent/node/blob/f8c335d0caf47f16d31413f89aa28eda3878e3aa/lib/util.js
 
-var getName = require('chai/lib/chai/utils/getName.js');
-var getProperties = require('chai/lib/chai/utils/getProperties.js');
-var getEnumerableProperties = require('chai/lib/chai/utils/getEnumerableProperties.js');
+var getName = require('./getName');
+var getProperties = require('./getProperties');
+var getEnumerableProperties = require('./getEnumerableProperties');
 
 module.exports = inspect;
 
@@ -4655,6 +4741,8 @@ module.exports = inspect;
  * @param {Number} depth Depth in which to descend in object. Default is 2.
  * @param {Boolean} colors Flag to turn on ANSI escape codes to color the
  *    output. Default is false (no coloring).
+ * @namespace Utils
+ * @name inspect
  */
 function inspect(obj, showHidden, depth, colors) {
   var ctx = {
@@ -4970,9 +5058,7 @@ function objectToString(o) {
   return Object.prototype.toString.call(o);
 }
 
-});
-
-require.register("chai/lib/chai/utils/objDisplay.js", function (exports, module) {
+},{"./getEnumerableProperties":15,"./getName":17,"./getProperties":20}],24:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -4983,8 +5069,8 @@ require.register("chai/lib/chai/utils/objDisplay.js", function (exports, module)
  * Module dependancies
  */
 
-var inspect = require('chai/lib/chai/utils/inspect.js');
-var config = require('chai/lib/chai/config.js');
+var inspect = require('./inspect');
+var config = require('../config');
 
 /**
  * ### .objDisplay (object)
@@ -4995,6 +5081,7 @@ var config = require('chai/lib/chai/config.js');
  *
  * @param {Mixed} javascript object to inspect
  * @name objDisplay
+ * @namespace Utils
  * @api public
  */
 
@@ -5023,9 +5110,63 @@ module.exports = function (obj) {
   }
 };
 
-});
+},{"../config":4,"./inspect":23}],25:[function(require,module,exports){
+/*!
+ * Chai - overwriteChainableMethod utility
+ * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
 
-require.register("chai/lib/chai/utils/overwriteMethod.js", function (exports, module) {
+/**
+ * ### overwriteChainableMethod (ctx, name, method, chainingBehavior)
+ *
+ * Overwites an already existing chainable method
+ * and provides access to the previous function or
+ * property.  Must return functions to be used for
+ * name.
+ *
+ *     utils.overwriteChainableMethod(chai.Assertion.prototype, 'length',
+ *       function (_super) {
+ *       }
+ *     , function (_super) {
+ *       }
+ *     );
+ *
+ * Can also be accessed directly from `chai.Assertion`.
+ *
+ *     chai.Assertion.overwriteChainableMethod('foo', fn, fn);
+ *
+ * Then can be used as any other assertion.
+ *
+ *     expect(myFoo).to.have.length(3);
+ *     expect(myFoo).to.have.length.above(3);
+ *
+ * @param {Object} ctx object whose method / property is to be overwritten
+ * @param {String} name of method / property to overwrite
+ * @param {Function} method function that returns a function to be used for name
+ * @param {Function} chainingBehavior function that returns a function to be used for property
+ * @namespace Utils
+ * @name overwriteChainableMethod
+ * @api public
+ */
+
+module.exports = function (ctx, name, method, chainingBehavior) {
+  var chainableBehavior = ctx.__methods[name];
+
+  var _chainingBehavior = chainableBehavior.chainingBehavior;
+  chainableBehavior.chainingBehavior = function () {
+    var result = chainingBehavior(_chainingBehavior).call(this);
+    return result === undefined ? this : result;
+  };
+
+  var _method = chainableBehavior.method;
+  chainableBehavior.method = function () {
+    var result = method(_method).apply(this, arguments);
+    return result === undefined ? this : result;
+  };
+};
+
+},{}],26:[function(require,module,exports){
 /*!
  * Chai - overwriteMethod utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -5061,6 +5202,7 @@ require.register("chai/lib/chai/utils/overwriteMethod.js", function (exports, mo
  * @param {Object} ctx object whose method is to be overwritten
  * @param {String} name of method to overwrite
  * @param {Function} method function that returns a function to be used for name
+ * @namespace Utils
  * @name overwriteMethod
  * @api public
  */
@@ -5078,9 +5220,7 @@ module.exports = function (ctx, name, method) {
   }
 };
 
-});
-
-require.register("chai/lib/chai/utils/overwriteProperty.js", function (exports, module) {
+},{}],27:[function(require,module,exports){
 /*!
  * Chai - overwriteProperty utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -5116,6 +5256,7 @@ require.register("chai/lib/chai/utils/overwriteProperty.js", function (exports, 
  * @param {Object} ctx object whose property is to be overwritten
  * @param {String} name of property to overwrite
  * @param {Function} getter function that returns a getter function to be used for name
+ * @namespace Utils
  * @name overwriteProperty
  * @api public
  */
@@ -5136,66 +5277,7 @@ module.exports = function (ctx, name, getter) {
   });
 };
 
-});
-
-require.register("chai/lib/chai/utils/overwriteChainableMethod.js", function (exports, module) {
-/*!
- * Chai - overwriteChainableMethod utility
- * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
- * MIT Licensed
- */
-
-/**
- * ### overwriteChainableMethod (ctx, name, method, chainingBehavior)
- *
- * Overwites an already existing chainable method
- * and provides access to the previous function or
- * property.  Must return functions to be used for
- * name.
- *
- *     utils.overwriteChainableMethod(chai.Assertion.prototype, 'length',
- *       function (_super) {
- *       }
- *     , function (_super) {
- *       }
- *     );
- *
- * Can also be accessed directly from `chai.Assertion`.
- *
- *     chai.Assertion.overwriteChainableMethod('foo', fn, fn);
- *
- * Then can be used as any other assertion.
- *
- *     expect(myFoo).to.have.length(3);
- *     expect(myFoo).to.have.length.above(3);
- *
- * @param {Object} ctx object whose method / property is to be overwritten
- * @param {String} name of method / property to overwrite
- * @param {Function} method function that returns a function to be used for name
- * @param {Function} chainingBehavior function that returns a function to be used for property
- * @name overwriteChainableMethod
- * @api public
- */
-
-module.exports = function (ctx, name, method, chainingBehavior) {
-  var chainableBehavior = ctx.__methods[name];
-
-  var _chainingBehavior = chainableBehavior.chainingBehavior;
-  chainableBehavior.chainingBehavior = function () {
-    var result = chainingBehavior(_chainingBehavior).call(this);
-    return result === undefined ? this : result;
-  };
-
-  var _method = chainableBehavior.method;
-  chainableBehavior.method = function () {
-    var result = method(_method).apply(this, arguments);
-    return result === undefined ? this : result;
-  };
-};
-
-});
-
-require.register("chai/lib/chai/utils/test.js", function (exports, module) {
+},{}],28:[function(require,module,exports){
 /*!
  * Chai - test utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -5206,7 +5288,7 @@ require.register("chai/lib/chai/utils/test.js", function (exports, module) {
  * Module dependancies
  */
 
-var flag = require('chai/lib/chai/utils/flag.js');
+var flag = require('./flag');
 
 /**
  * # test(object, expression)
@@ -5215,6 +5297,8 @@ var flag = require('chai/lib/chai/utils/flag.js');
  *
  * @param {Object} object (constructed Assertion)
  * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name test
  */
 
 module.exports = function (obj, args) {
@@ -5223,9 +5307,7 @@ module.exports = function (obj, args) {
   return negate ? !expr : expr;
 };
 
-});
-
-require.register("chai/lib/chai/utils/transferFlags.js", function (exports, module) {
+},{"./flag":13}],29:[function(require,module,exports){
 /*!
  * Chai - transferFlags utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -5250,6 +5332,7 @@ require.register("chai/lib/chai/utils/transferFlags.js", function (exports, modu
  * @param {Assertion} assertion the assertion to transfer the flags from
  * @param {Object} object the object to transfer the flags to; usually a new assertion
  * @param {Boolean} includeAll
+ * @namespace Utils
  * @name transferFlags
  * @api private
  */
@@ -5271,62 +5354,666 @@ module.exports = function (assertion, object, includeAll) {
   }
 };
 
-});
-
-require.register("chai/lib/chai/utils/type.js", function (exports, module) {
+},{}],30:[function(require,module,exports){
 /*!
- * Chai - type utility
- * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
+ * assertion-error
+ * Copyright(c) 2013 Jake Luer <jake@qualiancy.com>
  * MIT Licensed
  */
+
+/*!
+ * Return a function that will copy properties from
+ * one object to another excluding any originally
+ * listed. Returned function will create a new `{}`.
+ *
+ * @param {String} excluded properties ...
+ * @return {Function}
+ */
+
+function exclude () {
+  var excludes = [].slice.call(arguments);
+
+  function excludeProps (res, obj) {
+    Object.keys(obj).forEach(function (key) {
+      if (!~excludes.indexOf(key)) res[key] = obj[key];
+    });
+  }
+
+  return function extendExclude () {
+    var args = [].slice.call(arguments)
+      , i = 0
+      , res = {};
+
+    for (; i < args.length; i++) {
+      excludeProps(res, args[i]);
+    }
+
+    return res;
+  };
+};
+
+/*!
+ * Primary Exports
+ */
+
+module.exports = AssertionError;
+
+/**
+ * ### AssertionError
+ *
+ * An extension of the JavaScript `Error` constructor for
+ * assertion and validation scenarios.
+ *
+ * @param {String} message
+ * @param {Object} properties to include (optional)
+ * @param {callee} start stack function (optional)
+ */
+
+function AssertionError (message, _props, ssf) {
+  var extend = exclude('name', 'message', 'stack', 'constructor', 'toJSON')
+    , props = extend(_props || {});
+
+  // default values
+  this.message = message || 'Unspecified AssertionError';
+  this.showDiff = false;
+
+  // copy from properties
+  for (var key in props) {
+    this[key] = props[key];
+  }
+
+  // capture stack trace
+  ssf = ssf || arguments.callee;
+  if (ssf && Error.captureStackTrace) {
+    Error.captureStackTrace(this, ssf);
+  } else {
+    this.stack = new Error().stack;
+  }
+}
+
+/*!
+ * Inherit from Error.prototype
+ */
+
+AssertionError.prototype = Object.create(Error.prototype);
+
+/*!
+ * Statically set name
+ */
+
+AssertionError.prototype.name = 'AssertionError';
+
+/*!
+ * Ensure correct constructor
+ */
+
+AssertionError.prototype.constructor = AssertionError;
+
+/**
+ * Allow errors to be converted to JSON for static transfer.
+ *
+ * @param {Boolean} include stack (default: `true`)
+ * @return {Object} object that can be `JSON.stringify`
+ */
+
+AssertionError.prototype.toJSON = function (stack) {
+  var extend = exclude('constructor', 'toJSON', 'stack')
+    , props = extend({ name: this.name }, this);
+
+  // include stack if exists and not turned off
+  if (false !== stack && this.stack) {
+    props.stack = this.stack;
+  }
+
+  return props;
+};
+
+},{}],31:[function(require,module,exports){
+module.exports = require('./lib/eql');
+
+},{"./lib/eql":32}],32:[function(require,module,exports){
+/*!
+ * deep-eql
+ * Copyright(c) 2013 Jake Luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/*!
+ * Module dependencies
+ */
+
+var type = require('type-detect');
+
+/*!
+ * Buffer.isBuffer browser shim
+ */
+
+var Buffer;
+try { Buffer = require('buffer').Buffer; }
+catch(ex) {
+  Buffer = {};
+  Buffer.isBuffer = function() { return false; }
+}
+
+/*!
+ * Primary Export
+ */
+
+module.exports = deepEqual;
+
+/**
+ * Assert super-strict (egal) equality between
+ * two objects of any type.
+ *
+ * @param {Mixed} a
+ * @param {Mixed} b
+ * @param {Array} memoised (optional)
+ * @return {Boolean} equal match
+ */
+
+function deepEqual(a, b, m) {
+  if (sameValue(a, b)) {
+    return true;
+  } else if ('date' === type(a)) {
+    return dateEqual(a, b);
+  } else if ('regexp' === type(a)) {
+    return regexpEqual(a, b);
+  } else if (Buffer.isBuffer(a)) {
+    return bufferEqual(a, b);
+  } else if ('arguments' === type(a)) {
+    return argumentsEqual(a, b, m);
+  } else if (!typeEqual(a, b)) {
+    return false;
+  } else if (('object' !== type(a) && 'object' !== type(b))
+  && ('array' !== type(a) && 'array' !== type(b))) {
+    return sameValue(a, b);
+  } else {
+    return objectEqual(a, b, m);
+  }
+}
+
+/*!
+ * Strict (egal) equality test. Ensures that NaN always
+ * equals NaN and `-0` does not equal `+0`.
+ *
+ * @param {Mixed} a
+ * @param {Mixed} b
+ * @return {Boolean} equal match
+ */
+
+function sameValue(a, b) {
+  if (a === b) return a !== 0 || 1 / a === 1 / b;
+  return a !== a && b !== b;
+}
+
+/*!
+ * Compare the types of two given objects and
+ * return if they are equal. Note that an Array
+ * has a type of `array` (not `object`) and arguments
+ * have a type of `arguments` (not `array`/`object`).
+ *
+ * @param {Mixed} a
+ * @param {Mixed} b
+ * @return {Boolean} result
+ */
+
+function typeEqual(a, b) {
+  return type(a) === type(b);
+}
+
+/*!
+ * Compare two Date objects by asserting that
+ * the time values are equal using `saveValue`.
+ *
+ * @param {Date} a
+ * @param {Date} b
+ * @return {Boolean} result
+ */
+
+function dateEqual(a, b) {
+  if ('date' !== type(b)) return false;
+  return sameValue(a.getTime(), b.getTime());
+}
+
+/*!
+ * Compare two regular expressions by converting them
+ * to string and checking for `sameValue`.
+ *
+ * @param {RegExp} a
+ * @param {RegExp} b
+ * @return {Boolean} result
+ */
+
+function regexpEqual(a, b) {
+  if ('regexp' !== type(b)) return false;
+  return sameValue(a.toString(), b.toString());
+}
+
+/*!
+ * Assert deep equality of two `arguments` objects.
+ * Unfortunately, these must be sliced to arrays
+ * prior to test to ensure no bad behavior.
+ *
+ * @param {Arguments} a
+ * @param {Arguments} b
+ * @param {Array} memoize (optional)
+ * @return {Boolean} result
+ */
+
+function argumentsEqual(a, b, m) {
+  if ('arguments' !== type(b)) return false;
+  a = [].slice.call(a);
+  b = [].slice.call(b);
+  return deepEqual(a, b, m);
+}
+
+/*!
+ * Get enumerable properties of a given object.
+ *
+ * @param {Object} a
+ * @return {Array} property names
+ */
+
+function enumerable(a) {
+  var res = [];
+  for (var key in a) res.push(key);
+  return res;
+}
+
+/*!
+ * Simple equality for flat iterable objects
+ * such as Arrays or Node.js buffers.
+ *
+ * @param {Iterable} a
+ * @param {Iterable} b
+ * @return {Boolean} result
+ */
+
+function iterableEqual(a, b) {
+  if (a.length !==  b.length) return false;
+
+  var i = 0;
+  var match = true;
+
+  for (; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      match = false;
+      break;
+    }
+  }
+
+  return match;
+}
+
+/*!
+ * Extension to `iterableEqual` specifically
+ * for Node.js Buffers.
+ *
+ * @param {Buffer} a
+ * @param {Mixed} b
+ * @return {Boolean} result
+ */
+
+function bufferEqual(a, b) {
+  if (!Buffer.isBuffer(b)) return false;
+  return iterableEqual(a, b);
+}
+
+/*!
+ * Block for `objectEqual` ensuring non-existing
+ * values don't get in.
+ *
+ * @param {Mixed} object
+ * @return {Boolean} result
+ */
+
+function isValue(a) {
+  return a !== null && a !== undefined;
+}
+
+/*!
+ * Recursively check the equality of two objects.
+ * Once basic sameness has been established it will
+ * defer to `deepEqual` for each enumerable key
+ * in the object.
+ *
+ * @param {Mixed} a
+ * @param {Mixed} b
+ * @return {Boolean} result
+ */
+
+function objectEqual(a, b, m) {
+  if (!isValue(a) || !isValue(b)) {
+    return false;
+  }
+
+  if (a.prototype !== b.prototype) {
+    return false;
+  }
+
+  var i;
+  if (m) {
+    for (i = 0; i < m.length; i++) {
+      if ((m[i][0] === a && m[i][1] === b)
+      ||  (m[i][0] === b && m[i][1] === a)) {
+        return true;
+      }
+    }
+  } else {
+    m = [];
+  }
+
+  try {
+    var ka = enumerable(a);
+    var kb = enumerable(b);
+  } catch (ex) {
+    return false;
+  }
+
+  ka.sort();
+  kb.sort();
+
+  if (!iterableEqual(ka, kb)) {
+    return false;
+  }
+
+  m.push([ a, b ]);
+
+  var key;
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!deepEqual(a[key], b[key], m)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+},{"buffer":undefined,"type-detect":33}],33:[function(require,module,exports){
+module.exports = require('./lib/type');
+
+},{"./lib/type":34}],34:[function(require,module,exports){
+/*!
+ * type-detect
+ * Copyright(c) 2013 jake luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/*!
+ * Primary Exports
+ */
+
+var exports = module.exports = getType;
 
 /*!
  * Detectable javascript natives
  */
 
 var natives = {
-    '[object Arguments]': 'arguments'
-  , '[object Array]': 'array'
-  , '[object Date]': 'date'
-  , '[object Function]': 'function'
-  , '[object Number]': 'number'
+    '[object Array]': 'array'
   , '[object RegExp]': 'regexp'
-  , '[object String]': 'string'
+  , '[object Function]': 'function'
+  , '[object Arguments]': 'arguments'
+  , '[object Date]': 'date'
 };
 
 /**
- * ### type(object)
+ * ### typeOf (obj)
  *
- * Better implementation of `typeof` detection that can
- * be used cross-browser. Handles the inconsistencies of
- * Array, `null`, and `undefined` detection.
+ * Use several different techniques to determine
+ * the type of object being tested.
  *
- *     utils.type({}) // 'object'
- *     utils.type(null) // `null'
- *     utils.type(undefined) // `undefined`
- *     utils.type([]) // `array`
  *
- * @param {Mixed} object to detect type of
- * @name type
- * @api private
+ * @param {Mixed} object
+ * @return {String} object type
+ * @api public
  */
 
-module.exports = function (obj) {
+function getType (obj) {
   var str = Object.prototype.toString.call(obj);
   if (natives[str]) return natives[str];
   if (obj === null) return 'null';
   if (obj === undefined) return 'undefined';
   if (obj === Object(obj)) return 'object';
   return typeof obj;
+}
+
+exports.Library = Library;
+
+/**
+ * ### Library
+ *
+ * Create a repository for custom type detection.
+ *
+ * ```js
+ * var lib = new type.Library;
+ * ```
+ *
+ */
+
+function Library () {
+  this.tests = {};
+}
+
+/**
+ * #### .of (obj)
+ *
+ * Expose replacement `typeof` detection to the library.
+ *
+ * ```js
+ * if ('string' === lib.of('hello world')) {
+ *   // ...
+ * }
+ * ```
+ *
+ * @param {Mixed} object to test
+ * @return {String} type
+ */
+
+Library.prototype.of = getType;
+
+/**
+ * #### .define (type, test)
+ *
+ * Add a test to for the `.test()` assertion.
+ *
+ * Can be defined as a regular expression:
+ *
+ * ```js
+ * lib.define('int', /^[0-9]+$/);
+ * ```
+ *
+ * ... or as a function:
+ *
+ * ```js
+ * lib.define('bln', function (obj) {
+ *   if ('boolean' === lib.of(obj)) return true;
+ *   var blns = [ 'yes', 'no', 'true', 'false', 1, 0 ];
+ *   if ('string' === lib.of(obj)) obj = obj.toLowerCase();
+ *   return !! ~blns.indexOf(obj);
+ * });
+ * ```
+ *
+ * @param {String} type
+ * @param {RegExp|Function} test
+ * @api public
+ */
+
+Library.prototype.define = function (type, test) {
+  if (arguments.length === 1) return this.tests[type];
+  this.tests[type] = test;
+  return this;
 };
 
-});
+/**
+ * #### .test (obj, test)
+ *
+ * Assert that an object is of type. Will first
+ * check natives, and if that does not pass it will
+ * use the user defined custom tests.
+ *
+ * ```js
+ * assert(lib.test('1', 'int'));
+ * assert(lib.test('yes', 'bln'));
+ * ```
+ *
+ * @param {Mixed} object
+ * @param {String} type
+ * @return {Boolean} result
+ * @api public
+ */
 
-if (typeof exports == "object") {
-  module.exports = require("chai");
-} else if (typeof define == "function" && define.amd) {
-  define("chai", [], function(){ return require("chai"); });
-} else {
-  (this || window)["chai"] = require("chai");
+Library.prototype.test = function (obj, type) {
+  if (type === getType(obj)) return true;
+  var test = this.tests[type];
+
+  if (test && 'regexp' === getType(test)) {
+    return test.test(obj);
+  } else if (test && 'function' === getType(test)) {
+    return test(obj);
+  } else {
+    throw new ReferenceError('Type test "' + type + '" not defined or invalid.');
+  }
+};
+
+},{}],35:[function(require,module,exports){
+arguments[4][33][0].apply(exports,arguments)
+},{"./lib/type":36,"dup":33}],36:[function(require,module,exports){
+/*!
+ * type-detect
+ * Copyright(c) 2013 jake luer <jake@alogicalparadox.com>
+ * MIT Licensed
+ */
+
+/*!
+ * Primary Exports
+ */
+
+var exports = module.exports = getType;
+
+/**
+ * ### typeOf (obj)
+ *
+ * Use several different techniques to determine
+ * the type of object being tested.
+ *
+ *
+ * @param {Mixed} object
+ * @return {String} object type
+ * @api public
+ */
+var objectTypeRegexp = /^\[object (.*)\]$/;
+
+function getType(obj) {
+  var type = Object.prototype.toString.call(obj).match(objectTypeRegexp)[1].toLowerCase();
+  // Let "new String('')" return 'object'
+  if (typeof Promise === 'function' && obj instanceof Promise) return 'promise';
+  // PhantomJS has type "DOMWindow" for null
+  if (obj === null) return 'null';
+  // PhantomJS has type "DOMWindow" for undefined
+  if (obj === undefined) return 'undefined';
+  return type;
 }
-})()
+
+exports.Library = Library;
+
+/**
+ * ### Library
+ *
+ * Create a repository for custom type detection.
+ *
+ * ```js
+ * var lib = new type.Library;
+ * ```
+ *
+ */
+
+function Library() {
+  if (!(this instanceof Library)) return new Library();
+  this.tests = {};
+}
+
+/**
+ * #### .of (obj)
+ *
+ * Expose replacement `typeof` detection to the library.
+ *
+ * ```js
+ * if ('string' === lib.of('hello world')) {
+ *   // ...
+ * }
+ * ```
+ *
+ * @param {Mixed} object to test
+ * @return {String} type
+ */
+
+Library.prototype.of = getType;
+
+/**
+ * #### .define (type, test)
+ *
+ * Add a test to for the `.test()` assertion.
+ *
+ * Can be defined as a regular expression:
+ *
+ * ```js
+ * lib.define('int', /^[0-9]+$/);
+ * ```
+ *
+ * ... or as a function:
+ *
+ * ```js
+ * lib.define('bln', function (obj) {
+ *   if ('boolean' === lib.of(obj)) return true;
+ *   var blns = [ 'yes', 'no', 'true', 'false', 1, 0 ];
+ *   if ('string' === lib.of(obj)) obj = obj.toLowerCase();
+ *   return !! ~blns.indexOf(obj);
+ * });
+ * ```
+ *
+ * @param {String} type
+ * @param {RegExp|Function} test
+ * @api public
+ */
+
+Library.prototype.define = function(type, test) {
+  if (arguments.length === 1) return this.tests[type];
+  this.tests[type] = test;
+  return this;
+};
+
+/**
+ * #### .test (obj, test)
+ *
+ * Assert that an object is of type. Will first
+ * check natives, and if that does not pass it will
+ * use the user defined custom tests.
+ *
+ * ```js
+ * assert(lib.test('1', 'int'));
+ * assert(lib.test('yes', 'bln'));
+ * ```
+ *
+ * @param {Mixed} object
+ * @param {String} type
+ * @return {Boolean} result
+ * @api public
+ */
+
+Library.prototype.test = function(obj, type) {
+  if (type === getType(obj)) return true;
+  var test = this.tests[type];
+
+  if (test && 'regexp' === getType(test)) {
+    return test.test(obj);
+  } else if (test && 'function' === getType(test)) {
+    return test(obj);
+  } else {
+    throw new ReferenceError('Type test "' + type + '" not defined or invalid.');
+  }
+};
+
+},{}]},{},[1])(1)
+});

--- a/out/guide/helpers/index.html
+++ b/out/guide/helpers/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -203,7 +203,7 @@ core. </p>
 
 expect(arr).to.contain(<span class="number">2</span>);
 expect(obj).to.contain.key(<span class="string">'a'</span>);</code></pre>
-<p>For this to work, two seperate functions are needed. One that will be invoked when the 
+<p>For this to work, two separate functions are needed. One that will be invoked when the 
 chain is used as either a property or a method, and one that will be invoked when only used
 as a method. </p>
 <p>In these examples, and with all of the other chainable methods in core, the only function
@@ -254,7 +254,7 @@ to use when invoking the <code>age</code> method.</p>
     , age
   );
 }</code></pre>
-<p>By now, that should be self-explanitory. Now for our property function.</p>
+<p>By now, that should be self-explanatory. Now for our property function.</p>
 <pre><code class="lang-javascript"><span class="function"><span class="keyword">function</span> <span class="title">chainModelAge</span> <span class="params">()</span> {</span>
   utils.flag(<span class="keyword">this</span>, <span class="string">'model.age'</span>, <span class="literal">true</span>);
 }</code></pre>
@@ -311,11 +311,11 @@ trouble if we try to negate an <code>ok</code> assertion on a model.</p>
 <pre><code class="lang-javascript"><span class="keyword">var</span> arthur = <span class="keyword">new</span> Model(<span class="string">'person'</span>);
 arthur.set(<span class="string">'id'</span>, <span class="string">'dont panic'</span>);
 expect(arthur).to.not.be.ok;</code></pre>
-<p>We would expect this expection to pass as well, as our statement is
+<p>We would expect this expectation to pass as well, as our statement is
 negated and the id is not a number. Unfortunately, the negation flag
 was not passed to our number assertion, so it still expects the value
 to be a number. </p>
-<h5 id="transfering-flags">Transfering Flags</h5>
+<h5 id="transferring-flags">Transferring Flags</h5>
 <p>For this we will expand on this assertion by transfering all of the 
 flags from the original assertion to our new assertion. The final 
 property overwrite would look like this.</p>

--- a/out/guide/index.html
+++ b/out/guide/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -76,7 +76,7 @@
           <div class="wrap">
             <div class="rendered">
               <div class="header"><h1 id="welcome-to-chai">Welcome to Chai</h1>
-<p>We are glad that you have decided to give Chai.js a try! If this is your first visit, get aquainted with
+<p>We are glad that you have decided to give Chai.js a try! If this is your first visit, get acquainted with
 the basics, such as installation and our included assertion styles.</p>
 <h2 id="the-basics">The Basics</h2>
 <ul>
@@ -90,7 +90,7 @@ you want to achieve. The Plugin API is also intended as a way to simplify testin
 a way to encapsulate common assertions for repeat use. </p>
 <ul>
 <li><a href="/guide/plugins/">Core Plugin Concepts</a> covers the basics of using the Chai Plugin API.</li>
-<li><a href="/guide/helpers/">Building a Helper</a> is a walkthrough for writing your first plugin.</li>
+<li><a href="/guide/helpers/">Building a Helper</a> is a walk-through for writing your first plugin.</li>
 </ul>
 </div>
             </div>

--- a/out/guide/installation/index.html
+++ b/out/guide/installation/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/plugins/index.html
+++ b/out/guide/plugins/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -85,7 +85,7 @@ the language chain, and write your first assertion (and thorough error messages)
 finished here, <a href="/guide/helpers">Building a Helper</a> will show you how to compose properties and
 methods for use on the Chai language chain.</p>
 </div>
-              <article id="use-section"><h2 id="accessing-utilties">Accessing Utilties</h2>
+              <article id="use-section"><h2 id="accessing-utilities">Accessing Utilities</h2>
 <p>Chai comes with a number of utilities to assist in the construction of assertions,
 but it does not provide these directly on the <code>chai</code> export. These can be accessed 
 by using the <code>use</code> method of the chai export, which accepts a single function as

--- a/out/guide/resources/index.html
+++ b/out/guide/resources/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);

--- a/out/guide/styles/index.html
+++ b/out/guide/styles/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/guide.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -83,7 +83,7 @@ at the API Documentation for your selected style.</p>
               <article id="assert-section"><h2 id="assert">Assert</h2>
 <p><a href="/api/assert" class="clean-button">View full Assert API</a></p>
 <p>The assert style is exposed through <code>assert</code> interface. This provides
-the classic assert-dot notation, similiar to that packaged with
+the classic assert-dot notation, similar to that packaged with
 node.js. This assert module, however, provides several additional
 tests and is browser compatible.</p>
 <pre><code><span class="keyword">var</span> assert = require(<span class="string">'chai'</span>).assert
@@ -125,13 +125,13 @@ expect(answer).to.equal(<span class="number">42</span>);
 
 <span class="comment">// AssertionError: topic [answer]: expected 43 to equal 42.</span>
 expect(answer, <span class="string">'topic [answer]'</span>).to.equal(<span class="number">42</span>);</code></pre>
-<p>This comes in handy when being used with non-descript topics such as 
+<p>This comes in handy when being used with nondescript topics such as 
 booleans or numbers.</p>
 </article>
               <article id="should-section"><h3 id="should">Should</h3>
 <p>The <code>should</code> style allows for the same chainable assertions as the
 <code>expect</code> interface, however it extends each object with a <code>should</code>
-property to start your chain. This style has some issues when used Internet
+property to start your chain. This style has some issues when used with Internet
 Explorer, so be aware of browser compatibility. </p>
 <pre><code><span class="keyword">var</span> should = require(<span class="string">'chai'</span>).should() <span class="comment">//actually call the function</span>
   , foo = <span class="string">'bar'</span>

--- a/out/index.html
+++ b/out/index.html
@@ -10,10 +10,10 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="/public/js/jquery-mousewheel.js"></script>
     <script src="/public/js/antiscroll.js"></script>
-    <script src="/public/js/main.js?2.1.0"></script>
+    <script src="/public/js/main.js?3.4.2"></script>
     <script src="/public/js/home.js"></script>
-    <link rel="stylesheet" href="/public/css/antiscroll.css?2.1.0" type="text/css" media="all">
-    <link rel="stylesheet" href="/public/css/main.css?2.1.0" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/antiscroll.css?3.4.2" type="text/css" media="all">
+    <link rel="stylesheet" href="/public/css/main.css?3.4.2" type="text/css" media="all">
     <script type="text/javascript">
       var mpq = [];
       mpq.push(["init", "d5e84615dbd02dbc359b0f76d0ed7cf5"]);
@@ -59,7 +59,7 @@
           <div class="card-wrap">
             <div class="card">
               <div class="card-inner">
-                <h1>Download Chai<span class="version">v2.1.0</span></h1>
+                <h1>Download Chai<span class="version">v3.4.2</span></h1>
                 <div id="node" class="install">
                   <h2>for Node<small>Another platform?<a href="#browser" class="toggle">Browser</a><a href="#rails" class="toggle">Rails</a></small></h2>
                   <div class="download-banner"> 

--- a/out/public/js/tests/assert.js
+++ b/out/public/js/tests/assert.js
@@ -36,40 +36,52 @@ describe('assert', function () {
     }, "expected 'test' to be true");
   });
 
-  it('ok', function () {
-    assert.ok(true);
-    assert.ok(1);
-    assert.ok('test');
+  it('isNotTrue', function () {
+    assert.isNotTrue(false);
 
-    err(function () {
-      assert.ok(false);
-    }, "expected false to be truthy");
-
-    err(function () {
-      assert.ok(0);
-    }, "expected 0 to be truthy");
-
-    err(function () {
-      assert.ok('');
-    }, "expected '' to be truthy");
+    err(function() {
+      assert.isNotTrue(true);
+    }, "expected true to not equal true");
   });
 
-  it('notOk', function () {
-    assert.notOk(false);
-    assert.notOk(0);
-    assert.notOk('');
+  it('isOk / ok', function () {
+    ['isOk', 'ok'].forEach(function (isOk) {
+      assert[isOk](true);
+      assert[isOk](1);
+      assert[isOk]('test');
 
-    err(function () {
-      assert.notOk(true);
-    }, "expected true to be falsy");
+      err(function () {
+        assert[isOk](false);
+      }, "expected false to be truthy");
 
-    err(function () {
-      assert.notOk(1);
-    }, "expected 1 to be falsy");
+      err(function () {
+        assert[isOk](0);
+      }, "expected 0 to be truthy");
 
-    err(function () {
-      assert.notOk('test');
-    }, "expected 'test' to be falsy");
+      err(function () {
+        assert[isOk]('');
+      }, "expected '' to be truthy");
+    });
+  });
+
+  it('isNotOk, notOk', function () {
+    ['isNotOk', 'notOk'].forEach(function (isNotOk) {
+      assert[isNotOk](false);
+      assert[isNotOk](0);
+      assert[isNotOk]('');
+
+      err(function () {
+        assert[isNotOk](true);
+      }, "expected true to be falsy");
+
+      err(function () {
+        assert[isNotOk](1);
+      }, "expected 1 to be falsy");
+
+      err(function () {
+        assert[isNotOk]('test');
+      }, "expected 'test' to be falsy");
+    });
   });
 
   it('isFalse', function () {
@@ -84,12 +96,20 @@ describe('assert', function () {
     }, "expected 0 to be false");
   });
 
+  it('isNotFalse', function () {
+    assert.isNotFalse(true);
+
+    err(function() {
+      assert.isNotFalse(false);
+    }, "expected false to not equal false");
+  });
+
   it('equal', function () {
     var foo;
     assert.equal(foo, undefined);
   });
 
-  it('typeof / notTypeOf', function () {
+  it('typeof', function () {
     assert.typeOf('test', 'string');
     assert.typeOf(true, 'boolean');
     assert.typeOf(5, 'number');
@@ -281,6 +301,22 @@ describe('assert', function () {
     }, "expected null to not equal null");
   });
 
+  it('isNaN', function() {
+    assert.isNaN('hello');
+
+    err(function (){
+      assert.isNaN(4);
+    }, "expected 4 to be NaN");
+  });
+
+  it('isNotNaN', function() {
+    assert.isNotNaN(4);
+
+    err(function (){
+      assert.isNotNaN('hello');
+    }, "expected 'hello' not to be NaN");
+  });
+
   it('isUndefined', function() {
     assert.isUndefined(undefined);
 
@@ -394,6 +430,7 @@ describe('assert', function () {
 
   it('include', function() {
     assert.include('foobar', 'bar');
+    assert.include('', '');
     assert.include([ 1, 2, 3], 3);
     assert.include({a:1, b:2}, {b:2});
 
@@ -401,15 +438,42 @@ describe('assert', function () {
       assert.include('foobar', 'baz');
     }, "expected \'foobar\' to include \'baz\'");
 
+    err(function(){
+      assert.include(true, true);
+    }, "object tested must be an array, an object, or a string, but boolean given");
+
+    err(function () {
+      assert.include(42, 'bar');
+    }, "object tested must be an array, an object, or a string, but number given");
+
+    err(function(){
+      assert.include(null, 42);
+    }, "object tested must be an array, an object, or a string, but null given");
+
     err(function () {
       assert.include(undefined, 'bar');
-    }, "expected undefined to include 'bar'");
+    }, "object tested must be an array, an object, or a string, but undefined given");
   });
 
   it('notInclude', function () {
     assert.notInclude('foobar', 'baz');
     assert.notInclude([ 1, 2, 3 ], 4);
-    assert.notInclude(undefined, 'bar');
+
+    err(function(){
+      assert.notInclude(true, true);
+    }, "object tested must be an array, an object, or a string, but boolean given");
+
+    err(function () {
+      assert.notInclude(42, 'bar');
+    }, "object tested must be an array, an object, or a string, but number given");
+
+    err(function(){
+      assert.notInclude(null, 42);
+    }, "object tested must be an array, an object, or a string, but null given");
+
+    err(function () {
+      assert.notInclude(undefined, 'bar');
+    }, "object tested must be an array, an object, or a string, but undefined given");
 
     err(function () {
       assert.notInclude('foobar', 'bar');
@@ -445,7 +509,10 @@ describe('assert', function () {
   it('property', function () {
     var obj = { foo: { bar: 'baz' } };
     var simpleObj = { foo: 'bar' };
+    var undefinedKeyObj = { foo: undefined };
     assert.property(obj, 'foo');
+    assert.property(undefinedKeyObj, 'foo');
+    assert.propertyVal(undefinedKeyObj, 'foo', undefined);
     assert.deepProperty(obj, 'foo.bar');
     assert.notProperty(obj, 'baz');
     assert.notProperty(obj, 'foo.bar');
@@ -474,6 +541,10 @@ describe('assert', function () {
     }, "expected { foo: 'bar' } to have a property 'foo' of 'ball', but got 'bar'");
 
     err(function () {
+      assert.propertyVal(simpleObj, 'foo', undefined);
+    }, "expected { foo: 'bar' } to have a property 'foo' of undefined, but got 'bar'");
+
+    err(function () {
       assert.deepPropertyVal(obj, 'foo.bar', 'ball');
     }, "expected { foo: { bar: 'baz' } } to have a deep property 'foo.bar' of 'ball', but got 'baz'");
 
@@ -486,44 +557,46 @@ describe('assert', function () {
     }, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
   });
 
-  it('throws', function() {
-    assert.throws(function() { throw new Error('foo'); });
-    assert.throws(function() { throw new Error('bar'); }, 'bar');
-    assert.throws(function() { throw new Error('bar'); }, /bar/);
-    assert.throws(function() { throw new Error('bar'); }, Error);
-    assert.throws(function() { throw new Error('bar'); }, Error, 'bar');
+  it('throws / throw / Throw', function() {
+    ['throws', 'throw', 'Throw'].forEach(function (throws) {
+      assert[throws](function() { throw new Error('foo'); });
+      assert[throws](function() { throw new Error('bar'); }, 'bar');
+      assert[throws](function() { throw new Error('bar'); }, /bar/);
+      assert[throws](function() { throw new Error('bar'); }, Error);
+      assert[throws](function() { throw new Error('bar'); }, Error, 'bar');
 
-    var thrownErr = assert.throws(function() { throw new Error('foo'); });
-    assert(thrownErr instanceof Error, 'assert.throws returns error');
-    assert(thrownErr.message === 'foo', 'assert.throws returns error message');
+      var thrownErr = assert[throws](function() { throw new Error('foo'); });
+      assert(thrownErr instanceof Error, 'assert.' + throws + ' returns error');
+      assert(thrownErr.message === 'foo', 'assert.' + throws + ' returns error message');
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, TypeError);
-     }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, TypeError);
+       }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, 'bar');
-     }, "expected [Function] to throw error including 'bar' but got 'foo'")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, 'bar');
+       }, "expected [Function] to throw error including 'bar' but got 'foo'")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, Error, 'bar');
-     }, "expected [Function] to throw error including 'bar' but got 'foo'")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, Error, 'bar');
+       }, "expected [Function] to throw error including 'bar' but got 'foo'")
 
-    err(function () {
-      assert.throws(function() { throw new Error('foo') }, TypeError, 'bar');
-     }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
+      err(function () {
+        assert[throws](function() { throw new Error('foo') }, TypeError, 'bar');
+       }, "expected [Function] to throw 'TypeError' but 'Error: foo' was thrown")
 
-    err(function () {
-      assert.throws(function() {});
-     }, "expected [Function] to throw an error");
+      err(function () {
+        assert[throws](function() {});
+       }, "expected [Function] to throw an error");
 
-    err(function () {
-        assert.throws(function() { throw new Error('') }, 'bar');
-    }, "expected [Function] to throw error including 'bar' but got ''");
+      err(function () {
+          assert[throws](function() { throw new Error('') }, 'bar');
+      }, "expected [Function] to throw error including 'bar' but got ''");
 
-    err(function () {
-        assert.throws(function() { throw new Error('') }, /bar/);
-    }, "expected [Function] to throw error matching /bar/ but got ''");
+      err(function () {
+          assert[throws](function() { throw new Error('') }, /bar/);
+      }, "expected [Function] to throw error matching /bar/ but got ''");
+    });
   });
 
   it('doesNotThrow', function() {
@@ -551,11 +624,15 @@ describe('assert', function () {
     assert.ifError(undefined);
 
     err(function () {
-      assert.ifError('foo');
-     }, "expected \'foo\' to be falsy");
+      var err = new Error('This is an error message');
+      assert.ifError(err);
+     }, 'This is an error message');
   });
 
   it('operator', function() {
+    // For testing undefined and null with == and ===
+    var w;
+
     assert.operator(1, '<', 2);
     assert.operator(2, '>', 1);
     assert.operator(1, '==', 1);
@@ -563,6 +640,10 @@ describe('assert', function () {
     assert.operator(1, '>=', 1);
     assert.operator(1, '!=', 2);
     assert.operator(1, '!==', 2);
+    assert.operator(1, '!==', '1');
+    assert.operator(w, '==', undefined);
+    assert.operator(w, '===', undefined);
+    assert.operator(w, '==', null);
 
     err(function () {
       assert.operator(1, '=', 2);
@@ -581,6 +662,10 @@ describe('assert', function () {
      }, "expected 1 to be == 2");
 
     err(function () {
+      assert.operator(1, '===', '1');
+     }, "expected 1 to be === \'1\'");
+
+    err(function () {
       assert.operator(2, '<=', 1);
      }, "expected 2 to be <= 1");
 
@@ -593,8 +678,14 @@ describe('assert', function () {
      }, "expected 1 to be != 1");
 
     err(function () {
-      assert.operator(1, '!==', '1');
-     }, "expected 1 to be !== \'1\'");
+      assert.operator(1, '!==', 1);
+     }, "expected 1 to be !== 1");
+
+    err(function () {
+      assert.operator(w, '===', null);
+     }, "expected undefined to be === null");
+
+
   });
 
   it('closeTo', function(){
@@ -616,11 +707,37 @@ describe('assert', function () {
 
     err(function() {
       assert.closeTo(1.5, "1.0", 0.5);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
 
     err(function() {
       assert.closeTo(1.5, 1.0, true);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+
+  it('approximately', function(){
+    assert.approximately(1.5, 1.0, 0.5);
+    assert.approximately(10, 20, 20);
+    assert.approximately(-10, 20, 30);
+
+    err(function(){
+      assert.approximately(2, 1.0, 0.5);
+    }, "expected 2 to be close to 1 +/- 0.5");
+
+    err(function(){
+      assert.approximately(-10, 20, 29);
+    }, "expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      assert.approximately([1.5], 1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      assert.approximately(1.5, "1.0", 0.5);
+    }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      assert.approximately(1.5, 1.0, true);
+    }, "the arguments to closeTo or approximately must be numbers");
   });
 
   it('members', function() {
@@ -651,6 +768,37 @@ describe('assert', function () {
     }, 'expected [ 1, 54 ] to have the same members as [ 6, 1, 54 ]');
   });
 
+  it('oneOf', function() {
+    assert.oneOf(1, [1, 2, 3]);
+
+    var three = [3];
+    assert.oneOf(three, [1, 2, three]);
+
+    var four = { four: 4 };
+    assert.oneOf(four, [1, 2, four]);
+
+    err(function() {
+      assert.oneOf(1, 1);
+    }, 'expected 1 to be an array');
+
+    err(function() {
+      assert.oneOf(1, { a: 1 });
+    }, 'expected { a: 1 } to be an array');
+
+    err(function() {
+      assert.oneOf(9, [1, 2, 3], 'Message');
+    }, 'Message: expected 9 to be one of [ 1, 2, 3 ]');
+
+    err(function() {
+      assert.oneOf([3], [1, 2, [3]]);
+    }, 'expected [ 3 ] to be one of [ 1, 2, [ 3 ] ]');
+
+    err(function() {
+      assert.oneOf({ four: 4 }, [1, 2, { four: 4 }]);
+    }, 'expected { four: 4 } to be one of [ 1, 2, { four: 4 } ]');
+
+  });
+
   it('above', function() {
     assert.isAbove(5, 2, '5 should be above 2');
 
@@ -663,6 +811,15 @@ describe('assert', function () {
     }, 'expected 1 to be above 1');
   });
 
+  it('atLeast', function() {
+    assert.isAtLeast(5, 2, '5 should be above 2');
+    assert.isAtLeast(1, 1, '1 should be equal to 1');
+
+    err(function() {
+      assert.isAtLeast(1, 3);
+    }, 'expected 1 to be at least 3');
+  });
+
   it('below', function() {
     assert.isBelow(2, 5, '2 should be below 5');
 
@@ -673,13 +830,22 @@ describe('assert', function () {
     err(function() {
       assert.isBelow(1, 1);
     }, 'expected 1 to be below 1');
-  
+
   });
-    
+
+  it('atMost', function() {
+    assert.isAtMost(2, 5, '2 should be below 5');
+    assert.isAtMost(1, 1, '1 should be equal to 1');
+
+    err(function() {
+      assert.isAtMost(3, 1);
+    }, 'expected 3 to be at most 1');
+  });
+
   it('memberDeepEquals', function() {
     assert.sameDeepMembers([ {b: 3}, {a: 2}, {c: 5} ], [ {c: 5}, {b: 3}, {a: 2} ], 'same deep members');
     assert.sameDeepMembers([ {b: 3}, {a: 2}, 5, "hello" ], [ "hello", 5, {b: 3}, {a: 2} ], 'same deep members');
-    
+
     err(function() {
       assert.sameDeepMembers([ {b: 3} ], [ {c: 3} ])
     }, 'expected [ { b: 3 } ] to have the same members as [ { c: 3 } ]');
@@ -713,4 +879,165 @@ describe('assert', function () {
     assert.doesNotIncrease(smFn, obj, 'value');
   });
 
+  it('isExtensible / extensible', function() {
+    ['isExtensible', 'extensible'].forEach(function (isExtensible) {
+      var nonExtensibleObject = Object.preventExtensions({});
+
+      assert[isExtensible]({});
+
+      err(function() {
+        assert[isExtensible](nonExtensibleObject);
+      }, 'expected {} to be extensible');
+
+      // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+      err(function() {
+        assert[isExtensible](42);
+      }, 'expected 42 to be extensible');
+
+      err(function() {
+        assert[isExtensible](null);
+      }, 'expected null to be extensible');
+
+      err(function() {
+        assert[isExtensible]('foo');
+      }, 'expected \'foo\' to be extensible');
+
+      err(function() {
+        assert[isExtensible](false);
+      }, 'expected false to be extensible');
+
+      err(function() {
+        assert[isExtensible](undefined);
+      }, 'expected undefined to be extensible');
+    });
+  });
+
+  it('isNotExtensible / notExtensible', function() {
+    ['isNotExtensible', 'notExtensible'].forEach(function (isNotExtensible) {
+      var nonExtensibleObject = Object.preventExtensions({});
+
+      assert[isNotExtensible](nonExtensibleObject);
+
+      err(function() {
+        assert[isNotExtensible]({});
+      }, 'expected {} to not be extensible');
+
+      // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+      assert[isNotExtensible](42);
+      assert[isNotExtensible](null);
+      assert[isNotExtensible]('foo');
+      assert[isNotExtensible](false);
+      assert[isNotExtensible](undefined);
+    });
+  });
+
+  it('isSealed / sealed', function() {
+    ['isSealed', 'sealed'].forEach(function (isSealed) {
+      var sealedObject = Object.seal({});
+
+      assert[isSealed](sealedObject);
+
+      err(function() {
+        assert[isSealed]({});
+      }, 'expected {} to be sealed');
+
+      // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+      assert[isSealed](42);
+      assert[isSealed](null);
+      assert[isSealed]('foo');
+      assert[isSealed](false);
+      assert[isSealed](undefined);
+    });
+  });
+
+  it('isNotSealed / notSealed', function() {
+    ['isNotSealed', 'notSealed'].forEach(function (isNotSealed) {
+      var sealedObject = Object.seal({});
+
+      assert[isNotSealed]({});
+
+      err(function() {
+        assert[isNotSealed](sealedObject);
+      }, 'expected {} to not be sealed');
+
+      // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+      err(function() {
+        assert[isNotSealed](42);
+      }, 'expected 42 to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](null);
+      }, 'expected null to not be sealed');
+
+      err(function() {
+        assert[isNotSealed]('foo');
+      }, 'expected \'foo\' to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](false);
+      }, 'expected false to not be sealed');
+
+      err(function() {
+        assert[isNotSealed](undefined);
+      }, 'expected undefined to not be sealed');
+    });
+  });
+
+  it('isFrozen / frozen', function() {
+    ['isFrozen', 'frozen'].forEach(function (isFrozen) {
+      var frozenObject = Object.freeze({});
+
+      assert[isFrozen](frozenObject);
+
+      err(function() {
+        assert[isFrozen]({});
+      }, 'expected {} to be frozen');
+
+      // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+      assert[isFrozen](42);
+      assert[isFrozen](null);
+      assert[isFrozen]('foo');
+      assert[isFrozen](false);
+      assert[isFrozen](undefined);
+    });
+  });
+
+  it('isNotFrozen / notFrozen', function() {
+    ['isNotFrozen', 'notFrozen'].forEach(function (isNotFrozen) {
+      var frozenObject = Object.freeze({});
+
+      assert[isNotFrozen]({});
+
+      err(function() {
+        assert[isNotFrozen](frozenObject);
+      }, 'expected {} to not be frozen');
+
+      // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+      err(function() {
+        assert[isNotFrozen](42);
+      }, 'expected 42 to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](null);
+      }, 'expected null to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen]('foo');
+      }, 'expected \'foo\' to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](false);
+      }, 'expected false to not be frozen');
+
+      err(function() {
+        assert[isNotFrozen](undefined);
+      }, 'expected undefined to not be frozen');
+    });
+  });
 });

--- a/out/public/js/tests/configuration.js
+++ b/out/public/js/tests/configuration.js
@@ -21,8 +21,11 @@ describe('configuration', function () {
   function fooThrows () {
     chai.expect('foo').to.be.equal('bar');
   }
+  function fooPropThrows () {
+    chai.expect('foo').to.not.exist;
+  }
 
-  it('includeStack is true', function () {
+  it('includeStack is true for method assertions', function () {
     chai.config.includeStack = true;
 
     try {
@@ -38,7 +41,7 @@ describe('configuration', function () {
 
   });
 
-  it('includeStack is false', function () {
+  it('includeStack is false for method assertions', function () {
     chai.config.includeStack = false;
 
     try {
@@ -51,6 +54,40 @@ describe('configuration', function () {
       if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
         assert.notInclude(err.stack, 'assertEqual', 'should not have internal stack trace in error message');
         assert.include(err.stack, 'fooThrows', 'should have user stack trace in error message');
+      }
+    }
+  });
+
+  it('includeStack is true for property assertions', function () {
+    chai.config.includeStack = true;
+
+    try {
+      fooPropThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      // not all browsers support err.stack
+      // Phantom does not include function names for getter exec
+      if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
+        assert.include(err.stack, 'addProperty', 'should have internal stack trace in error message');
+        assert.include(err.stack, 'fooPropThrows', 'should have user stack trace in error message');
+      }
+    }
+
+  });
+
+  it('includeStack is false for property assertions', function () {
+    chai.config.includeStack = false;
+
+    try {
+      fooPropThrows();
+      assert.ok(false, 'should not get here because error thrown');
+    } catch (err) {
+      // IE 10 supports err.stack in Chrome format, but without
+      // `Error.captureStackTrace` support that allows tuning of the error
+      // message.
+      if ('undefined' !== typeof err.stack && 'undefined' !== typeof Error.captureStackTrace) {
+        assert.notInclude(err.stack, 'addProperty', 'should not have internal stack trace in error message');
+        assert.include(err.stack, 'fooPropThrows', 'should have user stack trace in error message');
       }
     }
   });

--- a/out/public/js/tests/expect.js
+++ b/out/public/js/tests/expect.js
@@ -264,10 +264,15 @@ describe('expect', function () {
 
   it('match(regexp)', function(){
     expect('foobar').to.match(/^foo/)
+    expect('foobar').to.matches(/^foo/)
     expect('foobar').to.not.match(/^bar/)
 
     err(function(){
       expect('foobar').to.match(/^bar/i, 'blah')
+    }, "blah: expected 'foobar' to match /^bar/i");
+
+    err(function(){
+      expect('foobar').to.matches(/^bar/i, 'blah')
     }, "blah: expected 'foobar' to match /^bar/i");
 
     err(function(){
@@ -394,6 +399,26 @@ describe('expect', function () {
     }, "expected { foo: \'bar\' } to be empty");
   });
 
+  it('NaN', function() {
+    expect(NaN).to.be.NaN;
+    expect('foo').to.be.NaN;
+    expect({}).to.be.NaN;
+    expect(4).not.to.be.NaN;
+    expect([]).not.to.be.NaN;
+
+    err(function(){
+      expect(4).to.be.NaN;
+    }, "expected 4 to be NaN");
+
+    err(function(){
+      expect([]).to.be.NaN;
+    }, "expected [] to be NaN");
+
+    err(function(){
+      expect('foo').not.to.be.NaN;
+    }, "expected 'foo' not to be NaN");
+  });
+
   it('property(name)', function(){
     expect('test').to.have.property('length');
     expect(4).to.not.have.property('length');
@@ -410,6 +435,9 @@ describe('expect', function () {
     });
     expect(obj).to.have.property('foo');
     expect(obj).to.have.property('bar');
+
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.property('foo.bar[]');
 
     err(function(){
       expect('asd').to.have.property('foo');
@@ -429,6 +457,9 @@ describe('expect', function () {
     expect({ 'foo': [1, 2, 3] })
       .to.have.deep.property('foo[1]');
 
+    expect({ 'foo.bar[]': 'baz'})
+      .to.have.deep.property('foo\\.bar\\[\\]');
+
     err(function(){
       expect({ 'foo.bar': 'baz' })
         .to.have.deep.property('foo.bar');
@@ -446,6 +477,12 @@ describe('expect', function () {
     expect(deepObj).to.have.deep.property('green.tea', 'matcha');
     expect(deepObj).to.have.deep.property('teas[1]', 'matcha');
     expect(deepObj).to.have.deep.property('teas[2].tea', 'konacha');
+
+    expect(deepObj).to.have.property('teas')
+      .that.is.an('array')
+      .with.deep.property('[2]')
+        .that.deep.equals({tea: 'konacha'});
+
     err(function(){
       expect(deepObj).to.have.deep.property('teas[3]');
     }, "expected { Object (green, teas) } to have a deep property 'teas[3]'");
@@ -455,7 +492,7 @@ describe('expect', function () {
     err(function(){
       expect(deepObj).to.have.deep.property('teas[3].tea', 'bar');
     }, "expected { Object (green, teas) } to have a deep property 'teas[3].tea'");
-    
+
     var arr = [
         [ 'chai', 'matcha', 'konacha' ]
       , [ { tea: 'chai' }
@@ -519,6 +556,40 @@ describe('expect', function () {
     }, "blah: expected { length: 12 } to not have own property 'length'");
   });
 
+  it('ownPropertyDescriptor(name)', function(){
+    expect('test').to.have.ownPropertyDescriptor('length');
+    expect('test').to.haveOwnPropertyDescriptor('length');
+    expect('test').not.to.have.ownPropertyDescriptor('foo');
+
+    var obj = {};
+    var descriptor = {
+      configurable: false,
+      enumerable: true,
+      writable: true,
+      value: NaN
+    };
+    Object.defineProperty(obj, 'test', descriptor);
+    expect(obj).to.have.ownPropertyDescriptor('test', descriptor);
+    err(function(){
+      expect(obj).not.to.have.ownPropertyDescriptor('test', descriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to not match \{ [^\}]+ \}$/);
+    err(function(){
+      var wrongDescriptor = {
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: NaN
+      };
+      expect(obj).to.have.ownPropertyDescriptor('test', wrongDescriptor, 'blah');
+    }, /^blah: expected the own property descriptor for 'test' on \{ test: NaN \} to match \{ [^\}]+ \}, got \{ [^\}]+ \}$/);
+
+    err(function(){
+      expect(obj).to.have.ownPropertyDescriptor('test2', 'blah');
+    }, "blah: expected { test: NaN } to have an own property descriptor for 'test2'");
+
+    expect(obj).to.have.ownPropertyDescriptor('test').and.have.property('enumerable', true);
+  });
+
   it('string()', function(){
     expect('foobar').to.have.string('bar');
     expect('foobar').to.have.string('foo');
@@ -572,6 +643,38 @@ describe('expect', function () {
     err(function(){
       expect([{a:1},{b:2}]).to.not.include({b:2});
     }, "expected [ { a: 1 }, { b: 2 } ] to not include { b: 2 }");
+
+    err(function(){
+      expect(true).to.include(true);
+    }, "object tested must be an array, an object, or a string, but boolean given");
+
+    err(function(){
+      expect(42.0).to.include(42);
+    }, "object tested must be an array, an object, or a string, but number given");
+
+    err(function(){
+      expect(null).to.include(42);
+    }, "object tested must be an array, an object, or a string, but null given");
+
+    err(function(){
+      expect(undefined).to.include(42);
+    }, "object tested must be an array, an object, or a string, but undefined given");
+
+    err(function(){
+      expect(true).to.not.include(true);
+    }, "object tested must be an array, an object, or a string, but boolean given");
+
+    err(function(){
+      expect(42.0).to.not.include(42);
+    }, "object tested must be an array, an object, or a string, but number given");
+
+    err(function(){
+      expect(null).to.not.include(42);
+    }, "object tested must be an array, an object, or a string, but null given");
+
+    err(function(){
+      expect(undefined).to.not.include(42);
+    }, "object tested must be an array, an object, or a string, but undefined given");
   });
 
   it('keys(array|Object|arguments)', function(){
@@ -943,11 +1046,45 @@ describe('expect', function () {
 
     err(function() {
       expect(1.5).to.be.closeTo("1.0", 0.5);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
 
     err(function() {
       expect(1.5).to.be.closeTo(1.0, true);
-    }, "the arguments to closeTo must be numbers");
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+
+  it('approximately', function(){
+    expect(1.5).to.be.approximately(1.0, 0.5);
+    expect(10).to.be.approximately(20, 20);
+    expect(-10).to.be.approximately(20, 30);
+
+    err(function(){
+      expect(2).to.be.approximately(1.0, 0.5, 'blah');
+    }, "blah: expected 2 to be close to 1 +/- 0.5");
+
+    err(function(){
+      expect(-10).to.be.approximately(20, 29, 'blah');
+    }, "blah: expected -10 to be close to 20 +/- 29");
+
+    err(function() {
+      expect([1.5]).to.be.approximately(1.0, 0.5);
+    }, "expected [ 1.5 ] to be a number");
+
+    err(function() {
+      expect(1.5).to.be.approximately("1.0", 0.5);
+    }, "the arguments to closeTo or approximately must be numbers");
+
+    err(function() {
+      expect(1.5).to.be.approximately(1.0, true);
+    }, "the arguments to closeTo or approximately must be numbers");
+  });
+
+  it('oneOf', function() {
+    expect(1).to.be.oneOf([1, 2, 3]);
+    expect('1').to.not.be.oneOf([1, 2, 3]);
+    expect([3, [4]]).to.not.be.oneOf([1, 2, [3, 4]]);
+    var threeFour = [3, [4]];
+    expect(threeFour).to.be.oneOf([1, 2, threeFour]);
   });
 
   it('include.members', function() {
@@ -1009,5 +1146,132 @@ describe('expect', function () {
     expect(decFn).to.decrease(obj, 'value');
   });
 
+  it('extensible', function() {
+    var nonExtensibleObject = Object.preventExtensions({});
 
+    expect({}).to.be.extensible;
+    expect(nonExtensibleObject).to.not.be.extensible;
+
+    err(function() {
+        expect(nonExtensibleObject).to.be.extensible;
+    }, 'expected {} to be extensible');
+
+    err(function() {
+        expect({}).to.not.be.extensible;
+    }, 'expected {} to not be extensible');
+
+    // Making sure ES6-like Object.isExtensible response is respected for all primitive types
+
+    expect(42).to.not.be.extensible;
+    expect(null).to.not.be.extensible;
+    expect('foo').to.not.be.extensible;
+    expect(false).to.not.be.extensible;
+    expect(undefined).to.not.be.extensible;
+
+    err(function() {
+      expect(42).to.be.extensible;
+    }, 'expected 42 to be extensible');
+
+    err(function() {
+      expect(null).to.be.extensible;
+    }, 'expected null to be extensible');
+
+    err(function() {
+      expect('foo').to.be.extensible;
+    }, 'expected \'foo\' to be extensible');
+
+    err(function() {
+      expect(false).to.be.extensible;
+    }, 'expected false to be extensible');
+
+    err(function() {
+      expect(undefined).to.be.extensible;
+    }, 'expected undefined to be extensible');
+  });
+
+  it('sealed', function() {
+    var sealedObject = Object.seal({});
+
+    expect(sealedObject).to.be.sealed;
+    expect({}).to.not.be.sealed;
+
+    err(function() {
+        expect({}).to.be.sealed;
+    }, 'expected {} to be sealed');
+
+    err(function() {
+        expect(sealedObject).to.not.be.sealed;
+    }, 'expected {} to not be sealed');
+
+    // Making sure ES6-like Object.isSealed response is respected for all primitive types
+
+    expect(42).to.be.sealed;
+    expect(null).to.be.sealed;
+    expect('foo').to.be.sealed;
+    expect(false).to.be.sealed;
+    expect(undefined).to.be.sealed;
+
+    err(function() {
+      expect(42).to.not.be.sealed;
+    }, 'expected 42 to not be sealed');
+
+    err(function() {
+      expect(null).to.not.be.sealed;
+    }, 'expected null to not be sealed');
+
+    err(function() {
+      expect('foo').to.not.be.sealed;
+    }, 'expected \'foo\' to not be sealed');
+
+    err(function() {
+      expect(false).to.not.be.sealed;
+    }, 'expected false to not be sealed');
+
+    err(function() {
+      expect(undefined).to.not.be.sealed;
+    }, 'expected undefined to not be sealed');
+  });
+
+  it('frozen', function() {
+    var frozenObject = Object.freeze({});
+
+    expect(frozenObject).to.be.frozen;
+    expect({}).to.not.be.frozen;
+
+    err(function() {
+        expect({}).to.be.frozen;
+    }, 'expected {} to be frozen');
+
+    err(function() {
+        expect(frozenObject).to.not.be.frozen;
+    }, 'expected {} to not be frozen');
+
+    // Making sure ES6-like Object.isFrozen response is respected for all primitive types
+
+    expect(42).to.be.frozen;
+    expect(null).to.be.frozen;
+    expect('foo').to.be.frozen;
+    expect(false).to.be.frozen;
+    expect(undefined).to.be.frozen;
+
+    err(function() {
+      expect(42).to.not.be.frozen;
+    }, 'expected 42 to not be frozen');
+
+    err(function() {
+      expect(null).to.not.be.frozen;
+    }, 'expected null to not be frozen');
+
+    err(function() {
+      expect('foo').to.not.be.frozen;
+    }, 'expected \'foo\' to not be frozen');
+
+    err(function() {
+      expect(false).to.not.be.frozen;
+    }, 'expected false to not be frozen');
+
+    err(function() {
+      expect(undefined).to.not.be.frozen;
+    }, 'expected undefined to not be frozen');
+  });
 });

--- a/out/public/js/tests/utilities.js
+++ b/out/public/js/tests/utilities.js
@@ -90,6 +90,9 @@ describe('utilities', function () {
           dimensions: {
             units: 'mm',
             lengths: [[1.2, 3.5], [2.2, 1.5], [5, 7]]
+          },
+          'dimensions.lengths': {
+            '[2]': [1.2, 3.5]
           }
         };
 
@@ -151,6 +154,15 @@ describe('utilities', function () {
       expect(info.value).to.be.undefined;
       info.name.should.equal(5);
       info.exists.should.be.false;
+    });
+
+    it('should handle backslash-escaping for .[]', function() {
+      var info = gpi('dimensions\\.lengths.\\[2\\][1]', obj);
+
+      info.parent.should.equal(obj['dimensions.lengths']['[2]']);
+      info.value.should.equal(obj['dimensions.lengths']['[2]'][1]);
+      info.name.should.equal(1);
+      info.exists.should.be.true;
     });
   });
 


### PR DESCRIPTION
I saw #74 regarding porting to Jekyll, but unfortunately I don't have time to help out with that right now as I have no familiarity with Jekyll, but I was thinking as a stopgap the current site could be updated for the latest version of Chai. I spent a while banging my head against the wall trying to figure out why my test wasn't working before realizing it was an error in the documentation which had been fixed but not updated on the website.