### PR TITLE
use "monospace" as the final fallback code font

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -1117,7 +1117,7 @@ table tr th {
 }
 code,
 pre {
-  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color: #333;
   font-size: 12px;
 }


### PR DESCRIPTION
All the code samples on the home page are in an ugly serifed font for me.

The CSS currently has:
  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
which means that unless you have one of exactly that set of fonts installed,
you get browser default.

The fix is to add "monospace" to the end of the list.