### PR TITLE
Expose a chai global for use in the console

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,4 +34,5 @@
             </ul>
         </div>
     </section>
+    <script src="/chai.js" type="text/javascript"></script>
 </footer>


### PR DESCRIPTION
This exposes the `chai` global on every page of the site, allowing people to test things in the dev console.

Being able to easily test a feature while reading its documentation can be very handy, and a few other documentation sites also expose globals for this purpose. ([lodash.com](https://lodash.com) exposes a `_` global, [bluebirdjs.com](http://bluebirdjs.com) exposes a `Promise` global, etc.)