### PR TITLE
Add a temporary note about the disabled test suite

### DIFF
--- a/api/test.md
+++ b/api/test.md
@@ -11,3 +11,5 @@ This is the test suite that we use to test Chai during development. Use it to co
 that Chai will function correctly in your browser environment (`should` does
 not work in IE9). These tests are powered by the awesome [Mocha](http://visionmedia.github.com/mocha/)
 test framework.
+
+***The test suite is currently missing, as discussed [on this issue](https://github.com/chaijs/chai-docs/issues/122). We welcome any help in bringing it back!***


### PR DESCRIPTION
Related to issue #122.

This is to prevent users to scratch their head as to why the tests are not running on their browsers.
It is of course a temporary measure before it gets re-added for real.