### PR TITLE
Fixed broken links, fixed broken anchors, removed duplicate main.css, fixed newline issue with site's description, fixed guide layout, and fixed slug in the guide's sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,14 +36,6 @@ defaults:
       layout: default
   -
     scope:
-      path: guide
-      type: guides
-    values:
-      layout: guide
-      bodyClass: guide
-      weight: 0
-  -
-    scope:
       path: api
     values:
       layout: api
@@ -53,7 +45,6 @@ collections:
   guides:
       output: true
       permalink: /guide/:path/
-      bodyClass: guide
 
 featuredplugin:
   name: chai-webdriver

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Chai
-description: |
+description: >
   Chai is a BDD / TDD assertion library for [node](http://nodejs.org) and the
   browser that can be delightfully paired with any javascript testing framework.
 baseurl: ""

--- a/_guides/helpers.md
+++ b/_guides/helpers.md
@@ -1,5 +1,8 @@
 ---
   title: Building a Helper
+  layout: guide
+  bodyClass: guide
+  weight: 0
   order: 40
   headings:
     - Adding Language Chains

--- a/_guides/helpers.md
+++ b/_guides/helpers.md
@@ -110,7 +110,7 @@ utils.addProperty(Assertion.prototype, 'model', function () {
 });
 ```
 
-<a href="/api/plugins/#addProperty-section" class="clean-button">View addProperty API</a>
+<a href="{{site.github.url}}/api/plugins/#addProperty-section" class="clean-button">View addProperty API</a>
 
 Simple and concise. Chai can take it from here. It is also worth mentioning that
 because this extension pattern is used so often, Chai makes it just a bit easier.
@@ -154,7 +154,7 @@ Assertion.addMethod('model', function (type) {
 });
 ```
 
-<a href="/api/plugins/#addMethod-section" class="clean-button">View addMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#addMethod-section" class="clean-button">View addMethod API</a>
 
 All calls to `assert` are synchronous, so if the first one fails the `AssertionError`
 is thrown and the second one will not be reached. It is up to the test runner to interpret
@@ -268,7 +268,7 @@ finish up here first...
 Assertion.addChainableMethod('age', assertModelAge, chainModelAge);
 ```
 
-<a href="/api/plugins/#addChainableMethod-section" class="clean-button">View addChainableMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#addChainableMethod-section" class="clean-button">View addChainableMethod API</a>
 
 Done. Now we can assert Arthur's exact age. We will pick up again with this example when learning how to overwrite methods.
 
@@ -308,7 +308,7 @@ chai.overwriteProperty('ok', function (_super) {
 });
 ```
 
-<a href="/api/plugins/#overwriteProperty-section" class="clean-button">View overwriteProperty API</a>
+<a href="{{site.github.url}}/api/plugins/#overwriteProperty-section" class="clean-button">View overwriteProperty API</a>
 
 ##### Overwrite Structure
 
@@ -426,7 +426,7 @@ Assertion.overwriteMethod('above', function (_super) {
 });
 ```
 
-<a href="/api/plugins/#overwriteMethod-section" class="clean-button">View overwriteMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#overwriteMethod-section" class="clean-button">View overwriteMethod API</a>
 
 This covers both positive and negative scenarios. No need to transfer flags in this
 case as `this.assert` handles that automatically. The same pattern can also be used

--- a/_guides/helpers.md
+++ b/_guides/helpers.md
@@ -110,7 +110,7 @@ utils.addProperty(Assertion.prototype, 'model', function () {
 });
 ```
 
-<a href="{{site.github.url}}/api/plugins/#addProperty-section" class="clean-button">View addProperty API</a>
+<a href="{{site.github.url}}/api/plugins/#method_addproperty" class="clean-button">View addProperty API</a>
 
 Simple and concise. Chai can take it from here. It is also worth mentioning that
 because this extension pattern is used so often, Chai makes it just a bit easier.
@@ -154,7 +154,7 @@ Assertion.addMethod('model', function (type) {
 });
 ```
 
-<a href="{{site.github.url}}/api/plugins/#addMethod-section" class="clean-button">View addMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#method_addmethod" class="clean-button">View addMethod API</a>
 
 All calls to `assert` are synchronous, so if the first one fails the `AssertionError`
 is thrown and the second one will not be reached. It is up to the test runner to interpret
@@ -268,7 +268,7 @@ finish up here first...
 Assertion.addChainableMethod('age', assertModelAge, chainModelAge);
 ```
 
-<a href="{{site.github.url}}/api/plugins/#addChainableMethod-section" class="clean-button">View addChainableMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#method_addchainablemethod" class="clean-button">View addChainableMethod API</a>
 
 Done. Now we can assert Arthur's exact age. We will pick up again with this example when learning how to overwrite methods.
 
@@ -308,7 +308,7 @@ chai.overwriteProperty('ok', function (_super) {
 });
 ```
 
-<a href="{{site.github.url}}/api/plugins/#overwriteProperty-section" class="clean-button">View overwriteProperty API</a>
+<a href="{{site.github.url}}/api/plugins/#method_overwriteproperty" class="clean-button">View overwriteProperty API</a>
 
 ##### Overwrite Structure
 
@@ -426,7 +426,7 @@ Assertion.overwriteMethod('above', function (_super) {
 });
 ```
 
-<a href="{{site.github.url}}/api/plugins/#overwriteMethod-section" class="clean-button">View overwriteMethod API</a>
+<a href="{{site.github.url}}/api/plugins/#method_overwritemethod" class="clean-button">View overwriteMethod API</a>
 
 This covers both positive and negative scenarios. No need to transfer flags in this
 case as `this.assert` handles that automatically. The same pattern can also be used

--- a/_guides/index.md
+++ b/_guides/index.md
@@ -12,8 +12,8 @@ assertion styles.
 
 ## The Basics
 
-- [Install Chai](/guide/installation/) in node, the browser, and other environments.
-- [Learn about styles](/guide/styles/) that you can use to define assertions.
+- [Install Chai]({{site.github.url}}/guide/installation/) in node, the browser, and other environments.
+- [Learn about styles]({{site.github.url}}/guide/styles/) that you can use to define assertions.
 
 ## Making Plugins
 
@@ -23,5 +23,5 @@ than what is included, limited only by what you want to achieve. The Plugin API
 is also intended as a way to simplify testing by providing users a way to
 encapsulate common assertions for repeat use.
 
-- [Core Plugin Concepts](/guide/plugins/) covers the basics of using the Chai Plugin API.
-- [Building a Helper](/guide/helpers/) is a walkthrough for writing your first plugin.
+- [Core Plugin Concepts]({{site.github.url}}/guide/plugins/) covers the basics of using the Chai Plugin API.
+- [Building a Helper]({{site.github.url}}/guide/helpers/) is a walkthrough for writing your first plugin.

--- a/_guides/index.md
+++ b/_guides/index.md
@@ -1,5 +1,8 @@
 ---
 title: Getting Started Guide
+layout: guide
+bodyClass: guide
+weight: 0
 permalink: /guide/
 order: 1
 ---

--- a/_guides/installation.md
+++ b/_guides/installation.md
@@ -1,5 +1,8 @@
 ---
   title: Installation
+  layout: guide
+  bodyClass: guide
+  weight: 0
   order: 10
   headings:
     - Node.js

--- a/_guides/plugins.md
+++ b/_guides/plugins.md
@@ -1,5 +1,8 @@
 ---
   title: Core Plugin Concepts
+  layout: guide
+  bodyClass: guide
+  weight: 0
   order: 30
   headings:
     - Accessing Utilities

--- a/_guides/resources.md
+++ b/_guides/resources.md
@@ -1,5 +1,8 @@
 ---
   title: Resources
+  layout: guide
+  bodyClass: guide
+  weight: 0
   order: 50
   headings:
     - Getting Help

--- a/_guides/styles.md
+++ b/_guides/styles.md
@@ -1,5 +1,8 @@
 ---
   title: Assertion Styles
+  layout: guide
+  bodyClass: guide
+  weight: 0
   order: 20
   headings:
     - Assert

--- a/_guides/styles.md
+++ b/_guides/styles.md
@@ -17,7 +17,7 @@ This section of the guide introduces you to the three different assertion styles
 
 ## Assert
 
-<a href="/api/assert" class="clean-button">View full Assert API</a>
+<a href="{{site.github.url}}/api/assert" class="clean-button">View full Assert API</a>
 
 The assert style is exposed through `assert` interface. This provides
 the classic assert-dot notation, similar to that packaged with
@@ -43,7 +43,7 @@ error messages should your assertion not pass.
 
 ## BDD
 
-<a href="/api/bdd" class="clean-button">View full BDD API</a>
+<a href="{{site.github.url}}/api/bdd" class="clean-button">View full BDD API</a>
 
 The BDD style comes in two flavors: `expect` and `should`. Both use the same
 chainable language to construct assertions, but they differ in the way an

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -27,7 +27,7 @@
                                 <div class="command dsp-left">
                                     $ npm install chai
                                 </div>
-                                <a href="{{site.github.url}}/guide/installation/#node" class="button dsp-right">
+                                <a href="{{site.github.url}}/guide/installation/#nodejs" class="button dsp-right">
                                     View Node Guide
                                 </a>
                             </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,6 @@
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | markdownify | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
     <link rel='icon' type='image/x-icon' href="{{site.github.url}}/img/favicon.ico">
-    <link rel="stylesheet" href="{{site.github.url}}/css/main.css">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.github.url | prepend: site.url }}">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>

--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-bodyClass: guide
 ---
 
 <nav id="guide" class="sidebar sticky">

--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -22,7 +22,7 @@ layout: default
       {% if guide.headings %}
       <div id="{{ slug }}" class="subitems">
           {% for heading in guide.headings %}
-          {% assign headingSlug = heading | slugify %}
+          {% assign headingSlug = heading | slugify: 'pretty' | remove: '.' %}
           <a href="#{{ headingSlug }}" class="item secondary group-{{ slug }}{{ expanded }}">{{ heading }}</a>
           {% endfor %}
       </div>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ assert.lengthOf(tea.flavors, 3);
             <div class="wrap">
                 <h3 class="fancy">Custom Plugins</h3>
                 <p>Browse our growing directory of custom plugins &amp; vendor integrations to find the best tool for your needs.</p>
-                <div class="more-wrap"><a href="/plugins" class="more">Browse Plugins<span class="arrow">&rarr;</span></a></div>
+                <div class="more-wrap"><a href="{{site.github.url}}/plugins" class="more">Browse Plugins<span class="arrow">&rarr;</span></a></div>
             </div>
         </article>
         <article id="plugin-guide" class="grid_3 plugin-box contrast"><span class="img">
@@ -121,7 +121,7 @@ assert.lengthOf(tea.flavors, 3);
             <div class="wrap">
                 <h3 class="fancy">Develop Plugins</h3>
                 <p>Chai has an extensive utility belt for plugin developers. Learn how to build your plugins &amp; share.</p>
-                <div class="more-wrap"><a href="/guide/plugins" class="more">Plugin Guide<span class="arrow">&rarr;</span></a></div>
+                <div class="more-wrap"><a href="{{site.github.url}}/guide/plugins" class="more">Plugin Guide<span class="arrow">&rarr;</span></a></div>
             </div>
         </article>
     </div>


### PR DESCRIPTION
This PR features lots of bug fixes. Some of these bugs were only present if you browsed your gh-pages version of the site and so they weren't present on [chaijs.com](chaijs.com). You can see my gh-pages here, http://aaronsofaly.github.io/chai-docs/.

I'll explain each commit.

[This commit](https://github.com/aaronsofaly/chai-docs/commit/bb799d353a341641dc68ebf42d45b0112d09cd5f) fixes broken links. Some links didn't have `{{site.github.url}}`, so when you browsed your gh-pages version of the site then the links would be 404.

[This commit](https://github.com/aaronsofaly/chai-docs/commit/2a736d29e87ec13a8a26950c775eb7826b23e3ce) fixes broken anchors.

[This commit](https://github.com/aaronsofaly/chai-docs/commit/e68ff18a0a49640d35ec2f51130739149ace9216) fixes duplicate main.css references in head.html. You can see the duplicate references on lines [10](https://github.com/chaijs/chai-docs/blob/master/_includes/head.html#L10) and [20](https://github.com/chaijs/chai-docs/blob/master/_includes/head.html#L20).

[This commit](https://github.com/aaronsofaly/chai-docs/commit/afcae8cbed57fd8a13180fd32bf8c97d0a227a17) fixes a newline issue in the site's description. I was only seeing this issue on my gh-pages and not on [chaijs.com](chaijs.com). [Here](https://github.com/chaijs/chai-docs/blob/master/_config.yml#L2-L4) is the original _config.yml. Because the description used a `|`, the second line of the description was converted to a `<br>`. I changed it from a `|` to a `>` because the `>` will convert a newline to a space instead of a `<br>`. This [Stackoverflow](http://stackoverflow.com/a/18708156/282906) answers explains it pretty well.

[This commit](https://github.com/aaronsofaly/chai-docs/commit/a8b31970dd258d0273118819c3b39b44811f80e3) fixes the sidebar in the guide. This one was tricky. The [_config.yml](https://github.com/chaijs/chai-docs/blob/master/_config.yml) file declares that the layout and body classes should be `"guide"`. However, gh-pages is completely ignoring that instead uses the default layout and does not add a body class. Therefore the guide doesn't have a sidebar on the [chaijs.com/guide/](chaijs.com/guide/) site. My local Jekyll compiles the sidebar just fine but for some reason gh-pages doesn't compile it properly and completely ignores what's in _config.yml. So I have moved what was declared in _config.yml to each of the guide pages.

[This commit](https://github.com/aaronsofaly/chai-docs/commit/e8b5322a5e0921165a9d4d23ffb7efc1f86d7659) fixes the slugs in the guide's sidebar. The [installation guide](https://github.com/chaijs/chai-docs/blob/master/_guides/installation.md) has a subheading of `Node.js`. When the subheading is parsed by Markdown then you get `<h3 id="nodejs">`. However, the guide's sidebar code creates a slug of `<a href="#node-js">`. So when you click the link in the sidebar it doesn't work because they don't match. So I updated the slug in the sidebar to preserve the period in `Node.js` and then I use a string filter to remove the period from the slug and so then you get `<a href="#nodejs">`.

There is still an outstanding issue though. Notice the sidebar on the [resources page of the guide](http://aaronsofaly.github.io/chai-docs/guide/resources/). There are two links of `Getting Help` and `Contributing`. However, the page content doesn't have these subheadings and so the sidebar links don't work. We need to change the links in the sidebar to match the actual subheadings in the page content.
