### PR TITLE
Correct typo in banner.html

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -100,7 +100,7 @@
         </div>
         <div class="callouts">
             <div id="guide" class="call"><a href="{{site.github.url}}/guide"><span class="icon"></span>
-                <big>Getting Started</big><small>Learn how install and use Chai through a series of guided walkthroughs.</small></a>
+                <big>Getting Started</big><small>Learn how to install and use Chai through a series of guided walkthroughs.</small></a>
                 <div class="bg"></div>
             </div>
             <div id="api" class="call"><a href="{{site.github.url}}/api"><span class="icon"></span>


### PR DESCRIPTION
Just a small fix for a typo that has been on the front page of the chaijs.com website for a while.

Missing the word "to" as shown by the screen shot:

![image](https://cloud.githubusercontent.com/assets/22520333/18998970/0136ac12-8709-11e6-8279-9a1b9637b097.png)


